### PR TITLE
Implements String Interlink Extensions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,8 @@ jobs:
       - git/shallow-checkout
       # Start: Swift Package Manager Workaround
       # Ref. https://support.circleci.com/hc/en-us/articles/360044709573-Swift-Package-Manager-fails-to-clone-from-private-Git-repositories
-      - run: rm ~/.ssh/id_rsa
+      - run: sudo defaults write com.apple.dt.Xcode IDEPackageSupportUseBuiltinSCM YES
+      - run: rm ~/.ssh/id_rsa || true
       - run: for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts || true
       # END: Swift Package Manager Workaround
       - ios/test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,11 @@ jobs:
       xcode-version: "12.0"
     steps:
       - git/shallow-checkout
+      # Start: Swift Package Manager Workaround
+      # Ref. https://support.circleci.com/hc/en-us/articles/360044709573-Swift-Package-Manager-fails-to-clone-from-private-Git-repositories
+      - run: rm ~/.ssh/id_rsa
+      - run: for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts || true
+      # END: Swift Package Manager Workaround
       - ios/test:
           xcode-version: "12.0"
           scheme: SimplenoteInterlinks

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,9 +5,9 @@
         "package": "SimplenoteFoundation",
         "repositoryURL": "https://github.com/Automattic/SimplenoteFoundation-Swift",
         "state": {
-          "branch": "issue/range-extensions",
-          "revision": "d0f6fb53f9d828506744770204ee70745637fba2",
-          "version": null
+          "branch": null,
+          "revision": "c5938f97ba6c041ae4c0f4030493f628f2263a41",
+          "version": "1.0.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/Automattic/SimplenoteFoundation-Swift",
         "state": {
           "branch": "issue/range-extensions",
-          "revision": "d0f6fb53f9d828506744770204ee70745637fba2",
+          "revision": "ad87f9be8b156ce3185a985d5b189416c0ec9fde",
           "version": null
         }
       }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SimplenoteFoundation",
+        "repositoryURL": "https://github.com/Automattic/SimplenoteFoundation-Swift",
+        "state": {
+          "branch": "issue/range-extensions",
+          "revision": "d0f6fb53f9d828506744770204ee70745637fba2",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,9 +5,9 @@
         "package": "SimplenoteFoundation",
         "repositoryURL": "https://github.com/Automattic/SimplenoteFoundation-Swift",
         "state": {
-          "branch": "issue/range-extensions",
-          "revision": "ad87f9be8b156ce3185a985d5b189416c0ec9fde",
-          "version": null
+          "branch": null,
+          "revision": "150e363b46f7c0d479a474c2c0a8d00648bbab97",
+          "version": "1.1.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,9 +5,9 @@
         "package": "SimplenoteFoundation",
         "repositoryURL": "https://github.com/Automattic/SimplenoteFoundation-Swift",
         "state": {
-          "branch": null,
-          "revision": "c5938f97ba6c041ae4c0f4030493f628f2263a41",
-          "version": "1.0.0"
+          "branch": "issue/range-extensions",
+          "revision": "d0f6fb53f9d828506744770204ee70745637fba2",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,7 @@ let package = Package(
         .package(
             name: "SimplenoteFoundation",
             url: "https://github.com/Automattic/SimplenoteFoundation-Swift",
-            from: "1.0.0"
-//            .branch("issue/range-extensions")
+            .branch("issue/range-extensions")
         )
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(
             name: "SimplenoteFoundation",
             url: "https://github.com/Automattic/SimplenoteFoundation-Swift",
-            .branch("issue/range-extensions")
+            from: "1.1.0"
         )
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -13,9 +13,18 @@ let package = Package(
             name: "SimplenoteInterlinks",
             targets: ["SimplenoteInterlinks"]),
     ],
-    dependencies: [],
+    dependencies: [
+        // Here we define our package's external dependencies
+        // and from where they can be fetched:
+        .package(
+            name: "SimplenoteFoundation",
+            url: "https://github.com/Automattic/SimplenoteFoundation-Swift",
+            .branch("issue/range-extensions")
+        )
+    ],
     targets: [
         .target(name: "SimplenoteInterlinks",
+                dependencies: ["SimplenoteFoundation"],
                 path: "Sources/SimplenoteInterlinks"),
         .testTarget(name: "SimplenoteInterlinksTests",
                     dependencies: ["SimplenoteInterlinks"])

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,8 @@ let package = Package(
         .package(
             name: "SimplenoteFoundation",
             url: "https://github.com/Automattic/SimplenoteFoundation-Swift",
-            .branch("issue/range-extensions")
+            from: "1.0.0"
+//            .branch("issue/range-extensions")
         )
     ],
     targets: [

--- a/Sources/SimplenoteInterlinks/Extensions/String+Interlinking.swift
+++ b/Sources/SimplenoteInterlinks/Extensions/String+Interlinking.swift
@@ -31,9 +31,8 @@ extension String {
             return nil
         }
 
-        let keywordStartIndex = index(lineRange.lowerBound, offsetBy: lhs.location(for: keywordIndex))
-        let keywordEndIndex = index(keywordStartIndex, offsetBy: keywordText.count)
-        let keywordRange = keywordStartIndex ..< keywordEndIndex
+        let keywordLocation = self.location(for: lineRange.lowerBound) + lhs.location(for: keywordIndex)
+        let keywordRange = rangeOfSubstring(at: keywordLocation, length: keywordText.count)
 
         return (keywordRange, keywordText)
     }
@@ -73,7 +72,6 @@ extension String {
             return nil
         }
 
-
         let keywordIndex = index(lastOpeningCharacterIndex, offsetBy: 1)
         let keywordString = self[keywordIndex..<endIndex]
         if keywordString.contains(closing) || keywordString.isEmpty {
@@ -103,6 +101,15 @@ extension String {
     ///
     func location(for index: String.Index) -> Int {
         return distance(from: startIndex, to: index)
+    }
+
+    /// Returns the `Range<String.Index>` for a Substring at the specified location
+    ///
+    func rangeOfSubstring(at location: Int, length: Int) -> Range<String.Index> {
+        let substringStartIndex = index(for: location)
+        let substringEndIndex = index(substringStartIndex, offsetBy: length)
+
+        return substringStartIndex ..< substringEndIndex
     }
 
     /// Returns the Relative Location of a given Location, within the specified range.

--- a/Sources/SimplenoteInterlinks/Extensions/String+Interlinking.swift
+++ b/Sources/SimplenoteInterlinks/Extensions/String+Interlinking.swift
@@ -42,16 +42,14 @@ extension String {
     func containsUnbalancedClosingCharacter(opening: Character, closing: Character) -> Bool {
         var stack = [Character]()
 
-        for character in self {
+        for character in self.reversed() {
             switch character {
-            case opening:
+            case closing:
                 stack.append(character)
 
-            case closing where !stack.isEmpty:
+            case opening:
                 _ = stack.popLast()
-
-            case closing where stack.isEmpty:
-                return true
+                // Note: We *don't care* about unbalanced opening characters!
 
             default:
                 continue

--- a/Sources/SimplenoteInterlinks/Extensions/String+Interlinking.swift
+++ b/Sources/SimplenoteInterlinks/Extensions/String+Interlinking.swift
@@ -1,0 +1,130 @@
+import Foundation
+
+
+// MARK: - String + Interlinking API(s)
+//
+extension String {
+
+    /// Returns the Interlink Keyword at the receiver's location, if any.
+    ///
+    /// - Parameters:
+    ///     - location: Location to analyze
+    ///     - opening: Opening Keyword Character
+    ///     - closing: Closing Keyword Character
+    ///
+    /// - Returns: Keyword, if any.
+    /// - Note: This API extracts the keyword at a given location, with this shape: `[keyword`.
+    /// - Important: If a closing character is found on the right hand side, this API returns nil
+    ///
+    func interlinkKeyword(at location: Int, opening: Character = Character("["), closing: Character = Character("]")) -> String? {
+        guard let (lineRange, lineText) = line(at: location) else {
+            return nil
+        }
+
+        let locationInLine = relativeLocation(for: location, in: lineRange)
+        let (lhs, rhs) = lineText.split(at: locationInLine)
+        if rhs.containsUnbalancedClosingCharacter(opening: opening, closing: closing) {
+            return nil
+        }
+
+        return lhs.trailingLookupKeyword(opening: opening, closing: closing)
+    }
+
+    /// Returns **true** whenever the receiver contains an unbalanced Closing Character
+    ///
+    func containsUnbalancedClosingCharacter(opening: Character, closing: Character) -> Bool {
+        var stack = [Character]()
+
+        for character in self {
+            switch character {
+            case opening:
+                stack.append(character)
+
+            case closing where !stack.isEmpty:
+                _ = stack.popLast()
+
+            case closing where stack.isEmpty:
+                return true
+
+            default:
+                continue
+            }
+        }
+
+        return stack.isEmpty == false
+    }
+
+    /// Looks up for the first `Opening Character` occurrence, starting from the tail of the receiver.
+    /// If located, this API will return the substring succeeding such character, only if such does not contain the Closing Character.
+    ///
+    /// - Example: `Text [keyword`
+    /// - Result: `keyword`
+    ///
+    func trailingLookupKeyword(opening: Character, closing: Character) -> String? {
+        guard let lastOpeningCharacterIndex = lastIndex(of: opening) else {
+            return nil
+        }
+
+
+        let tailStart = index(lastOpeningCharacterIndex, offsetBy: 1)
+        let tailString = self[tailStart..<endIndex]
+        if tailString.contains(closing) || tailString.isEmpty {
+            return nil
+        }
+
+        return String(tailString)
+    }
+
+    /// Splits the receiver at the specified location
+    ///
+    func split(at location: Int) -> (String, String) {
+        let locationAsIndex = index(for: location)
+        let lhs = String(self[startIndex..<locationAsIndex])
+        let rhs = String(self[locationAsIndex..<endIndex])
+
+        return (lhs, rhs)
+    }
+
+    /// Converts a Location (expressed as Integer) into a String.Index
+    ///
+    func index(for location: Int) -> String.Index {
+        return index(startIndex, offsetBy: location)
+    }
+
+    /// Converts a String.Index into a Location (expressed as integer)
+    ///
+    func location(for index: String.Index) -> Int {
+        return distance(from: startIndex, to: index)
+    }
+
+    /// Returns the Relative Location of a given Location, within the specified range.
+    /// For instance:
+    /// - Location: 10
+    /// - Range: (Location = 10, Length = 10)
+    /// - Relative Location: Zero!
+    ///
+    func relativeLocation(for location: Int, in range: Range<String.Index>) -> Int {
+        return location - self.location(for: range.lowerBound)
+    }
+
+    /// Returns a touple with (Range, Text) of the Line at the specified location
+    ///
+    func line(at location: Int) -> (Range<String.Index>, String)? {
+        guard let range = rangeOfLine(at: location) else {
+            return nil
+        }
+
+        return (range, String(self[range]))
+    }
+
+    /// Returns the range of the line at the specified location
+    ///
+    func rangeOfLine(at location: Int) -> Range<String.Index>? {
+        guard count >= location else {
+            return nil
+        }
+
+        let locationStartIndex = index(for: location)
+        return lineRange(for: locationStartIndex..<locationStartIndex)
+    }
+}

--- a/Sources/SimplenoteInterlinks/Extensions/String+Interlinking.swift
+++ b/Sources/SimplenoteInterlinks/Extensions/String+Interlinking.swift
@@ -39,15 +39,21 @@ extension String {
         }
 
         // Step #4: Extract any keywords on the LHS of the cursor's Index
-        guard let (keywordIndex, keywordText) = lhs.trailingLookupKeyword(opening: opening, closing: closing) else {
+        guard let (keywordIndexInLHS, keywordText) = lhs.trailingLookupKeyword(opening: opening, closing: closing) else {
             return nil
         }
 
         // Step #5: keywordStartIndex = Line Start + Keyword Start
-        let absoluteIndex = self.index(lineRange.lowerBound, offsetBy: lhs.distance(from: lhs.startIndex, to: keywordIndex))
-        let absoluteRange = absoluteIndex ..< self.index(absoluteIndex, offsetBy: keywordText.count)
+        let keywordIndex = self.index(lineRange.lowerBound, offsetBy: lhs.distance(from: lhs.startIndex, to: keywordIndexInLHS))
+        let keywordRange = range(for: keywordText, at: keywordIndex)
 
-        return (absoluteRange, keywordText)
+        return (keywordRange, keywordText)
+    }
+
+    /// Returns the Range for the specified Substring at a given Index
+    ///
+    func range(for substring: String, at substringIndex: String.Index) -> Range<String.Index> {
+        substringIndex ..< index(substringIndex, offsetBy: substring.count)
     }
 
     /// Returns **true** whenever the receiver contains an unbalanced Closing Character

--- a/Sources/SimplenoteInterlinks/Extensions/String+Interlinking.swift
+++ b/Sources/SimplenoteInterlinks/Extensions/String+Interlinking.swift
@@ -16,7 +16,7 @@ extension String {
     /// - Note: This API extracts the keyword at a given location, with this shape: `[keyword`.
     /// - Important: If a closing character is found on the right hand side, this API returns nil
     ///
-    public func interlinkKeyword(at location: Int, opening: Character = Character("["), closing: Character = Character("]")) -> (Int, String)? {
+    public func interlinkKeyword(at location: Int, opening: Character = Character("["), closing: Character = Character("]")) -> (Range<String.Index>, String)? {
         guard let (lineRange, lineText) = line(at: location) else {
             return nil
         }
@@ -31,8 +31,11 @@ extension String {
             return nil
         }
 
-        let absoluteKeywordLocation = self.location(for: lineRange.lowerBound) + lhs.location(for: keywordIndex)
-        return (absoluteKeywordLocation, keywordText)
+        let keywordAbsoluteStartIndex = index(lineRange.lowerBound, offsetBy: lhs.location(for: keywordIndex))
+        let keywordAbsoluteEndIndex = index(keywordAbsoluteStartIndex, offsetBy: keywordText.count)
+        let keywordAbsoluteRange = keywordAbsoluteStartIndex ..< keywordAbsoluteEndIndex
+
+        return (keywordAbsoluteRange, keywordText)
     }
 
     /// Returns **true** whenever the receiver contains an unbalanced Closing Character

--- a/Sources/SimplenoteInterlinks/Extensions/String+Interlinking.swift
+++ b/Sources/SimplenoteInterlinks/Extensions/String+Interlinking.swift
@@ -115,7 +115,7 @@ extension String {
         return location - self.location(for: range.lowerBound)
     }
 
-    /// Returns a touple with (Range, Text) of the Line at the specified location
+    /// Returns a tuple with `(Range, Text)` of the Line at the specified location
     ///
     func line(at location: Int) -> (Range<String.Index>, String)? {
         guard let range = rangeOfLine(at: location) else {
@@ -125,7 +125,7 @@ extension String {
         return (range, String(self[range]))
     }
 
-    /// Returns the range of the line at the specified location
+    /// Returns the range of the line at the specified `String.Index`
     ///
     func rangeOfLine(at location: Int) -> Range<String.Index>? {
         guard count >= location else {

--- a/Sources/SimplenoteInterlinks/Extensions/String+Interlinking.swift
+++ b/Sources/SimplenoteInterlinks/Extensions/String+Interlinking.swift
@@ -31,11 +31,11 @@ extension String {
             return nil
         }
 
-        let keywordAbsoluteStartIndex = index(lineRange.lowerBound, offsetBy: lhs.location(for: keywordIndex))
-        let keywordAbsoluteEndIndex = index(keywordAbsoluteStartIndex, offsetBy: keywordText.count)
-        let keywordAbsoluteRange = keywordAbsoluteStartIndex ..< keywordAbsoluteEndIndex
+        let keywordStartIndex = index(lineRange.lowerBound, offsetBy: lhs.location(for: keywordIndex))
+        let keywordEndIndex = index(keywordStartIndex, offsetBy: keywordText.count)
+        let keywordRange = keywordStartIndex ..< keywordEndIndex
 
-        return (keywordAbsoluteRange, keywordText)
+        return (keywordRange, keywordText)
     }
 
     /// Returns **true** whenever the receiver contains an unbalanced Closing Character

--- a/Sources/SimplenoteInterlinks/Extensions/String+Interlinking.swift
+++ b/Sources/SimplenoteInterlinks/Extensions/String+Interlinking.swift
@@ -16,7 +16,7 @@ extension String {
     /// - Note: This API extracts the keyword at a given location, with this shape: `[keyword`.
     /// - Important: If a closing character is found on the right hand side, this API returns nil
     ///
-    func interlinkKeyword(at location: Int, opening: Character = Character("["), closing: Character = Character("]")) -> String? {
+    public func interlinkKeyword(at location: Int, opening: Character = Character("["), closing: Character = Character("]")) -> String? {
         guard let (lineRange, lineText) = line(at: location) else {
             return nil
         }

--- a/Tests/SimplenoteInterlinksTests/StringInterlinkTests.swift
+++ b/Tests/SimplenoteInterlinksTests/StringInterlinkTests.swift
@@ -1,0 +1,280 @@
+import XCTest
+@testable import SimplenoteInterlinks
+
+
+// MARK: - String+Interlink Unit Tests
+//
+class StringInterlinkTests: XCTestCase {
+
+    /// Verifies that `interlinkKeyword(at:)` returns nil whenever the `[keyword` is not located at the left hand side of the specified location
+    ///
+    func testInterlinkKeywordReturnsNilWheneverTheSpecifiedLocationDoesNotContainTrailingOpeningBrackets() {
+        let keyword = "Some long keyword should be here"
+        let text = "irrelevant prefix string here [" + keyword
+
+        let rangeOfKeyword = text.range(of: keyword)!
+        let locationOfKeyword = text.location(for: rangeOfKeyword.lowerBound)
+
+        for location in 0..<locationOfKeyword {
+            XCTAssertNil(text.interlinkKeyword(at: location))
+        }
+    }
+
+    /// Verifies that `interlinkKeyword(at:)` returns the `[keyword substring` at the specified location
+    /// We use a `sample text containing [a simplenote innerlink`, and verify the keyword on the left hand side is always returned
+    ///
+    func testInterlinkKeywordReturnsTheTextOnTheLeftHandSideOfTheSpecifiedLocationAndPerformsSuper() {
+        let keyword = "Some long keyword should be here"
+        let lhs = String(repeating: "an extremely long text should probably go here ", count: 2048)
+        let text = lhs + "[" + keyword
+
+        let rangeOfKeyword = text.range(of: keyword)!
+        let locationOfKeyword = text.location(for: rangeOfKeyword.lowerBound)
+
+        for location in locationOfKeyword...text.count {
+            let currentIndex = text.index(for: location)
+            let expectedKeywordSlice = String(text[rangeOfKeyword.lowerBound ..< currentIndex])
+            let resultingKeywordSlice = text.interlinkKeyword(at: location) ?? ""
+
+            XCTAssertEqual(resultingKeywordSlice, expectedKeywordSlice)
+        }
+    }
+
+    /// Verifies that `interlinkKeyword(at:)` returns nil whenever the receiver contains an Opening Bracket, but no text
+    ///
+    func testInterlinkKeywordReturnsNilWheneverThereIsNoTextAfterOpeningBracket() {
+        let text = "["
+        XCTAssertNil(text.interlinkKeyword(at: .zero))
+    }
+
+    /// Verifies that `interlinkKeyword(at:)` returns nil whenever the receiver contains a properly closed Interlink
+    ///
+    func testInterlinkKeywordReturnsNilWheneverTheBracketsAreClosed() {
+        let text = "irrelevant prefix string here [Some text should also go here maybe!]"
+
+        for location in 0..<text.count {
+            XCTAssertNil(text.interlinkKeyword(at: location))
+        }
+    }
+
+    /// Verifies that `interlinkKeyword(at:)` can extract a new keyword being edited, located in between two closed keywords
+    ///
+    func testInterlinkKeywordReturnsTheProperSubstringWhenEditingSomeNewLinkInBetweenTwoProperlyFormedLinks() {
+        let keyword = "new keyword"
+        let text = "Hexadecimal is made up of [numbers](simplenote://note/123456) and [" + keyword + " [letters](simplenote://note/abcdef)."
+
+        let rangeOfKeyword = text.range(of: keyword)!
+        let keywordStart = text.location(for: rangeOfKeyword.lowerBound)
+        let keywordEnd = text.location(for: rangeOfKeyword.upperBound)
+
+        for location in keywordStart...keywordEnd {
+            let currentIndex = text.index(for: location)
+            let expectedKeywordSlice = String(text[rangeOfKeyword.lowerBound ..< currentIndex])
+            let resultingKeywordSlice = text.interlinkKeyword(at: location) ?? ""
+
+            XCTAssertEqual(resultingKeywordSlice, expectedKeywordSlice)
+        }
+    }
+
+    /// Verifies that `containsUnbalancedClosingCharacter` returns true whenever the receiver contains unbalanced balanced `[]` pairs
+    ///
+    func testContainsUnbalancedClosingCharacterReturnsTrueWhenTheReceiverContainsUnbalancedClosingCharacters() {
+        let samples = [
+            "[][",
+            "][]",
+            "[[]][",
+            "[[]]["
+        ]
+
+        for sample in samples {
+            XCTAssertTrue(sample.containsUnbalancedClosingCharacter(opening: Character("["), closing: Character("]")))
+        }
+    }
+
+    /// Verifies that `containsUnbalancedClosingCharacter` returns false whenever the receiver contains properly balanced `[]` pairs
+    ///
+    func testContainsUnbalancedClosingCharacterReturnsFalseWhenTheReceiverDoesNotContainUnbalancedClosingCharacters() {
+        let samples = [
+            "[]",
+            "[[]]",
+            "[[[]]]",
+            "[][][]"
+        ]
+
+        for sample in samples {
+            XCTAssertFalse(sample.containsUnbalancedClosingCharacter(opening: Character("["), closing: Character("]")))
+        }
+    }
+
+    /// Verifies that `trailingLookupKeyword(opening: closing)` returns nil whenever the receiver does not contain any lookup keywords
+    ///
+    func testTrailingLookupKeywordReturnsNilWhenThereAreNoLookupKeywords() {
+        let text = "qwertyuiop"
+        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
+
+        XCTAssertNil(result)
+    }
+
+    /// Verifies that `trailingLookupKeyword(opening: closing)` returns nil whenever the receiver contains a closed keyword
+    ///
+    func testTrailingLookupKeywordReturnsNilWhenTheLookupKeywordIsClosedYetEmpty() {
+        let text = "[]"
+        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
+
+        XCTAssertNil(result)
+    }
+
+    /// Verifies that `trailingLookupKeyword(opening: closing)` returns nil whenever the receiver contains multiple closed keywords
+    ///
+    func testTrailingLookupKeywordReturnsNilWhenThereAreNoUnclosedLookupKeywords() {
+        let text = "[keyword 1] lalalala [keyword 2] lalalalaa [keyword 3]"
+        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
+
+        XCTAssertNil(result)
+    }
+
+    /// Verifies that `trailingLookupKeyword(opening: closing)` returns any trailing `[lookup keyword`
+    /// - Note: It must not contain a closing `]`!
+    ///
+    func testTrailingLookupKeywordReturnsTheKeywordAfterTheOpeningCharacter() {
+        let keyword = "some keyword here"
+        let text = "qwertyuiop [" + keyword
+        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
+
+        XCTAssertEqual(result, keyword)
+    }
+
+    /// Verifies that `trailingLookupKeyword(opening: closing)` returns the trailing `[lookup keyword`, whenever there's more than one keyword
+    ///
+    func testTrailingLookupKeywordReturnsTheLastKeywordWhenThereAreManyKeywords() {
+        let keyword1 = "some keyword here"
+        let keyword2 = "the real keyword"
+
+        let text = "qwertyuiop [" + keyword1 + "] asdfghjkl [" + keyword2
+        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
+
+        XCTAssertEqual(result, keyword2)
+    }
+
+    /// Verifies that `trailingLookupKeyword(opening: closing)` works as expected, when the receiver actually starts with the `[lookup keyword`
+    ///
+    func testTrailingLookupKeywordWorksAsExpectedWheneverTheInputStringStartsWithTheOpeningCharacter() {
+        let keyword = "some keyword here"
+        let text = "[" + keyword
+        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
+
+        XCTAssertEqual(result, keyword)
+    }
+
+    /// Verifies that `trailingLookupKeyword(opening: closing)` returns nil whenever the receiver only contains an  opening character `[`
+    ///
+    func testTrailingLookupKeywordReturnsNilWhenTheActualKeywordIsEmpty() {
+        let text = "["
+        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
+
+        XCTAssertNil(result)
+    }
+
+
+
+    /// Verifies that `split(at:)` properly cuts the receiver at the specified location
+    ///
+    func testSplitAtLocationReturnsTheExpectedSubstrings() {
+        let lhs = "some random text on the left hand side"
+        let rhs = "and some more random text on the right hand side"
+        let text = lhs + rhs
+
+        let (splitLHS, splitRHS) = text.split(at: lhs.count)
+        XCTAssertEqual(lhs, splitLHS)
+        XCTAssertEqual(rhs, splitRHS)
+    }
+
+    /// Verifies that `split(at:)` properly handles Empty Strings
+    ///
+    func testSplitAtLocationReturnsEmptyStringsWhenTheReceiverIsEmpty() {
+        let (lhs, rhs) = "".split(at: .zero)
+
+        XCTAssertTrue(lhs.isEmpty)
+        XCTAssertTrue(rhs.isEmpty)
+    }
+
+    /// Verifies that `split(at:)` returns an empty `RHS` string, whenever the cut location matches the end of the receiver
+    ///
+    func testSplitAtLocationProperlyHandlesLocationsAtTheEndOfTheString() {
+        let text = "this is supposed to be a single but relatively long line of text"
+        let (lhs, rhs) = text.split(at: text.count)
+
+        XCTAssertEqual(lhs, text)
+        XCTAssertEqual(rhs, "")
+    }
+
+
+
+    /// Verifies that `relativeLocation(for: in:)` does not alter the Location, whenever the specified Range covers the full string
+    ///
+    func testRelativeLocationForLocationReturnsTheUnmodifiedLocationWhenTheRangeEnclosesTheFullString() {
+        let text = "this is supposed to be a single but relatively long line of text"
+
+        let substringRange = text.startIndex ..< text.endIndex
+        let substringStart = text.location(for: substringRange.lowerBound)
+        let substringEnd = text.location(for: substringRange.upperBound)
+
+        for location in substringStart..<substringEnd {
+            XCTAssertEqual(text.relativeLocation(for: location, in: substringRange), location)
+        }
+    }
+
+    /// Verifies that `relativeLocation(for: in:)` converts the specified Absolute Location into a Relative Location, with regards of a specified range
+    ///
+    func testRelativeLocationForLocationReturnsTheExpectedLocationWhenTheRangeIsNotTheFullString() {
+        let text = "this is supposed to be a single but relatively long line of text"
+
+        let substringRange = text.range(of: "line of text")!
+        let substringStart = text.location(for: substringRange.lowerBound)
+        let substringEnd = text.location(for: substringRange.upperBound)
+
+        for location in substringStart..<substringEnd {
+            XCTAssertEqual(text.relativeLocation(for: location, in: substringRange), location - substringStart)
+        }
+    }
+
+
+
+    /// Verifies that `line(at:)` returns a touple with Range + Text for the Line at the specified Location
+    ///
+    func testLineAtLocationReturnsTheExpectedLineForTheSpecifiedLocation() {
+        let lines = [
+            "alala lala long long le long long long!\n",
+            "this is supposed to be the second line\n",
+            "and this would be the third line in the document\n",
+            "only to be followed by a trailing and final line!"
+        ]
+
+        let text = lines.joined()
+        var padding = Int.zero
+
+        for line in lines {
+            for location in Int.zero ..< line.count {
+                let (_, lineText) = text.line(at: location + padding)!
+                XCTAssertEqual(lineText, line)
+            }
+
+            padding += line.count
+        }
+    }
+
+
+
+    /// Verifies that `rangeOfLine(at:)` returns `nil` whenever the specified location exceeds the receiver's length.
+    ///
+    func testLineAtLocationReturnsNilWheneverTheLocationExceedsTheValidBounds() {
+        let text = "text and some more text yes!"
+        let locationStart = text.count + 1
+        let locationEnd = text.count * 2
+
+        for location in locationStart ..< locationEnd {
+            XCTAssertNil(text.rangeOfLine(at: location))
+        }
+    }
+}
+

--- a/Tests/SimplenoteInterlinksTests/StringInterlinkTests.swift
+++ b/Tests/SimplenoteInterlinksTests/StringInterlinkTests.swift
@@ -233,6 +233,19 @@ class StringInterlinkTests: XCTestCase {
     }
 
 
+    /// Verifies that `rangeOfSubstring` properly builds a `Range<String.Index>` for the substring at the specified Location
+    ///
+    func testRangeOfSubstringAtLocationReturnsTheSwiftRangeForSomeSubstringAtTheSpecifiedLocation() {
+        let text = "Hello 🇮🇳 World 🌎!"
+        let substring = "🌎"
+
+        let expectedRange = text.range(of: substring)!
+        let location = text.location(for: expectedRange.lowerBound)
+
+        let resultingRange = text.rangeOfSubstring(at: location, length: substring.count)
+        XCTAssertEqual(expectedRange, resultingRange)
+    }
+
 
     /// Verifies that `relativeLocation(for: in:)` does not alter the Location, whenever the specified Range covers the full string
     ///

--- a/Tests/SimplenoteInterlinksTests/StringInterlinkTests.swift
+++ b/Tests/SimplenoteInterlinksTests/StringInterlinkTests.swift
@@ -9,8 +9,8 @@ class StringInterlinkTests: XCTestCase {
     /// Verifies that `interlinkKeyword(at:)` returns nil whenever the `[keyword` is not located at the left hand side of the specified location
     ///
     func testInterlinkKeywordReturnsNilWheneverTheSpecifiedLocationDoesNotContainTrailingOpeningBrackets() {
-        let lhs = "irrelevant prefix string here ["
-        let keyword = "Some long keyword should be here"
+        let lhs = "irrelevant 🇮🇳 prefix string here ["
+        let keyword = "Some long 🇮🇳 keyword should be here"
         let text = lhs + keyword
 
         for location in Int.zero ..< lhs.count {
@@ -23,8 +23,8 @@ class StringInterlinkTests: XCTestCase {
     /// We use a `sample text containing [a simplenote innerlink`, and verify the keyword on the left hand side is always returned
     ///
     func testInterlinkKeywordReturnsTheTextOnTheLeftHandSideOfTheSpecifiedLocationAndPerformsSuper() {
-        let keyword = "Some long keyword should be here"
-        let lhs = String(repeating: "an extremely long text should probably go here ", count: 2048)
+        let keyword = "Some long 🇮🇳 keyword should be here"
+        let lhs = String(repeating: "an 🇮🇳 extremely long text 🇮🇳 should probably go here ", count: 2048)
         let text = lhs + "[" + keyword
 
         let rangeOfKeyword = text.range(of: keyword)!
@@ -54,7 +54,7 @@ class StringInterlinkTests: XCTestCase {
     /// Verifies that `interlinkKeyword(at:)` returns nil whenever the receiver contains a properly closed Interlink
     ///
     func testInterlinkKeywordReturnsNilWheneverTheBracketsAreClosed() {
-        let text = "irrelevant prefix string here [Some text should also go here maybe!]"
+        let text = "irrelevant prefix string here 🇮🇳 [Some text should also go here maybe!]"
 
         for location in Int.zero ..< text.count {
             let index = text.index(text.startIndex, offsetBy: location)
@@ -150,7 +150,7 @@ class StringInterlinkTests: XCTestCase {
     /// Verifies that `trailingLookupKeyword(opening: closing)` returns nil whenever the receiver contains multiple closed keywords
     ///
     func testTrailingLookupKeywordReturnsNilWhenThereAreNoUnclosedLookupKeywords() {
-        let text = "[keyword 1] lalalala [keyword 2] lalalalaa [keyword 3]"
+        let text = "[keyword 🇮🇳 1] lalalala [keyword 🇮🇳 2] lalalalaa [keyword 🇮🇳 3]"
         let result = text.trailingLookupKeyword(opening: "[", closing: "]")
 
         XCTAssertNil(result)
@@ -160,8 +160,8 @@ class StringInterlinkTests: XCTestCase {
     /// - Note: It must not contain a closing `]`!
     ///
     func testTrailingLookupKeywordReturnsTheKeywordAfterTheOpeningCharacter() {
-        let keyword = "some keyword here"
-        let text = "qwertyuiop [" + keyword
+        let keyword = "some 🌎 keyword here"
+        let text = "qwertyuiop 🇮🇳 [" + keyword
         let range = text.range(of: keyword)
 
         guard let (resultIndex, resultText) = text.trailingLookupKeyword(opening: "[", closing: "]") else {
@@ -176,10 +176,10 @@ class StringInterlinkTests: XCTestCase {
     /// Verifies that `trailingLookupKeyword(opening: closing)` returns the trailing `[lookup keyword`, whenever there's more than one keyword
     ///
     func testTrailingLookupKeywordReturnsTheLastKeywordWhenThereAreManyKeywords() {
-        let keyword1 = "some keyword here"
-        let keyword2 = "the real keyword"
+        let keyword1 = "some 🇮🇳 keyword here"
+        let keyword2 = "the real 🌎 keyword"
 
-        let text = "qwertyuiop [" + keyword1 + "] asdfghjkl [" + keyword2
+        let text = "qwertyuiop 🇮🇳 [" + keyword1 + "] 🌎 asdfghjkl [" + keyword2
         let range = text.range(of: keyword2)
 
         guard let (resultIndex, resultText) = text.trailingLookupKeyword(opening: "[", closing: "]") else {
@@ -194,7 +194,7 @@ class StringInterlinkTests: XCTestCase {
     /// Verifies that `trailingLookupKeyword(opening: closing)` works as expected, when the receiver actually starts with the `[lookup keyword`
     ///
     func testTrailingLookupKeywordWorksAsExpectedWheneverTheInputStringStartsWithTheOpeningCharacter() {
-        let keyword = "some keyword here"
+        let keyword = "some 🌎 keyword here"
         let text = "[" + keyword
         let range = text.range(of: keyword)
 
@@ -214,66 +214,6 @@ class StringInterlinkTests: XCTestCase {
         let result = text.trailingLookupKeyword(opening: "[", closing: "]")
 
         XCTAssertNil(result)
-    }
-
-
-    /// Verifies that `split(at:)` properly cuts the receiver at the specified location
-    ///
-    func testSplitAtLocationReturnsTheExpectedSubstrings() {
-        let lhs = "some random 🇮🇳 text on the left hand side"
-        let rhs = "and some more 🌎 random text on the right hand side"
-        let text = lhs + rhs
-        let lhsEndIndex = text.index(text.startIndex, offsetBy: lhs.count)
-
-        let (splitLHS, splitRHS) = text.split(at: lhsEndIndex)
-        XCTAssertEqual(lhs, splitLHS)
-        XCTAssertEqual(rhs, splitRHS)
-    }
-
-    /// Verifies that `split(at:)` properly handles Empty Strings
-    ///
-    func testSplitAtLocationReturnsEmptyStringsWhenTheReceiverIsEmpty() {
-        let text = ""
-        let (lhs, rhs) = text.split(at: text.startIndex)
-
-        XCTAssertTrue(lhs.isEmpty)
-        XCTAssertTrue(rhs.isEmpty)
-    }
-
-    /// Verifies that `split(at:)` returns an empty `RHS` string, whenever the cut location matches the end of the receiver
-    ///
-    func testSplitAtLocationProperlyHandlesLocationsAtTheEndOfTheString() {
-        let text = "this is supposed to be a single but relatively long line of text"
-        let (lhs, rhs) = text.split(at: text.endIndex)
-
-        XCTAssertEqual(lhs, text)
-        XCTAssertEqual(rhs, "")
-    }
-
-    /// Verifies that `line(at:)` returns a touple with Range + Text for the Line at the specified Location
-    ///
-    func testLineAtIndexReturnsTheExpectedLineForTheSpecifiedLocation() {
-        let lines = [
-            "alala lala long long le long long long!\n",
-            "this is supposed to be the second line\n",
-            "and this would be the third line in the document\n",
-            "only to be followed by a trailing and final line!"
-        ]
-
-        let text = lines.joined()
-        var padding = Int.zero
-
-        for line in lines {
-            for location in Int.zero ..< line.count {
-                let index = text.index(text.startIndex, offsetBy: location + padding)
-                let (lineRange, lineText) = text.line(at: index)
-
-                XCTAssertEqual(lineText, line)
-                XCTAssertEqual(String(text[lineRange]), lineText)
-            }
-
-            padding += line.count
-        }
     }
 }
 

--- a/Tests/SimplenoteInterlinksTests/StringInterlinkTests.swift
+++ b/Tests/SimplenoteInterlinksTests/StringInterlinkTests.swift
@@ -34,9 +34,12 @@ class StringInterlinkTests: XCTestCase {
         for location in locationOfKeyword...text.count {
             let currentIndex = text.index(for: location)
             let expectedKeywordSlice = String(text[rangeOfKeyword.lowerBound ..< currentIndex])
-            let resultingKeywordSlice = text.interlinkKeyword(at: location) ?? ""
+            guard let (resultingKeywordIndex, resultingKeywordSlice) = text.interlinkKeyword(at: location) else {
+                continue
+            }
 
             XCTAssertEqual(resultingKeywordSlice, expectedKeywordSlice)
+            XCTAssertEqual(resultingKeywordIndex, text.location(for: rangeOfKeyword.lowerBound))
         }
     }
 
@@ -70,9 +73,12 @@ class StringInterlinkTests: XCTestCase {
         for location in keywordStart...keywordEnd {
             let currentIndex = text.index(for: location)
             let expectedKeywordSlice = String(text[rangeOfKeyword.lowerBound ..< currentIndex])
-            let resultingKeywordSlice = text.interlinkKeyword(at: location) ?? ""
+            guard let (resultingKeywordIndex, resultingKeywordSlice) = text.interlinkKeyword(at: location) else {
+                continue
+            }
 
             XCTAssertEqual(resultingKeywordSlice, expectedKeywordSlice)
+            XCTAssertEqual(resultingKeywordIndex, text.location(for: rangeOfKeyword.lowerBound))
         }
     }
 
@@ -139,9 +145,15 @@ class StringInterlinkTests: XCTestCase {
     func testTrailingLookupKeywordReturnsTheKeywordAfterTheOpeningCharacter() {
         let keyword = "some keyword here"
         let text = "qwertyuiop [" + keyword
-        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
+        let range = text.range(of: keyword)
 
-        XCTAssertEqual(result, keyword)
+        guard let (resultIndex, resultText) = text.trailingLookupKeyword(opening: "[", closing: "]") else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(resultText, keyword)
+        XCTAssertEqual(range?.lowerBound, resultIndex)
     }
 
     /// Verifies that `trailingLookupKeyword(opening: closing)` returns the trailing `[lookup keyword`, whenever there's more than one keyword
@@ -151,9 +163,15 @@ class StringInterlinkTests: XCTestCase {
         let keyword2 = "the real keyword"
 
         let text = "qwertyuiop [" + keyword1 + "] asdfghjkl [" + keyword2
-        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
+        let range = text.range(of: keyword2)
 
-        XCTAssertEqual(result, keyword2)
+        guard let (resultIndex, resultText) = text.trailingLookupKeyword(opening: "[", closing: "]") else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(resultText, keyword2)
+        XCTAssertEqual(range?.lowerBound, resultIndex)
     }
 
     /// Verifies that `trailingLookupKeyword(opening: closing)` works as expected, when the receiver actually starts with the `[lookup keyword`
@@ -161,9 +179,15 @@ class StringInterlinkTests: XCTestCase {
     func testTrailingLookupKeywordWorksAsExpectedWheneverTheInputStringStartsWithTheOpeningCharacter() {
         let keyword = "some keyword here"
         let text = "[" + keyword
-        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
+        let range = text.range(of: keyword)
 
-        XCTAssertEqual(result, keyword)
+        guard let (resultIndex, resultText) = text.trailingLookupKeyword(opening: "[", closing: "]") else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(resultText, keyword)
+        XCTAssertEqual(range?.lowerBound, resultIndex)
     }
 
     /// Verifies that `trailingLookupKeyword(opening: closing)` returns nil whenever the receiver only contains an  opening character `[`

--- a/Tests/SimplenoteInterlinksTests/StringInterlinkTests.swift
+++ b/Tests/SimplenoteInterlinksTests/StringInterlinkTests.swift
@@ -34,12 +34,12 @@ class StringInterlinkTests: XCTestCase {
         for location in locationOfKeyword...text.count {
             let currentIndex = text.index(for: location)
             let expectedKeywordSlice = String(text[rangeOfKeyword.lowerBound ..< currentIndex])
-            guard let (resultingKeywordIndex, resultingKeywordSlice) = text.interlinkKeyword(at: location) else {
+            guard let (resultingKeywordRange, resultingKeywordSlice) = text.interlinkKeyword(at: location) else {
                 continue
             }
 
             XCTAssertEqual(resultingKeywordSlice, expectedKeywordSlice)
-            XCTAssertEqual(resultingKeywordIndex, text.location(for: rangeOfKeyword.lowerBound))
+            XCTAssertEqual(expectedKeywordSlice, String(text[resultingKeywordRange]))
         }
     }
 
@@ -73,12 +73,12 @@ class StringInterlinkTests: XCTestCase {
         for location in keywordStart...keywordEnd {
             let currentIndex = text.index(for: location)
             let expectedKeywordSlice = String(text[rangeOfKeyword.lowerBound ..< currentIndex])
-            guard let (resultingKeywordIndex, resultingKeywordSlice) = text.interlinkKeyword(at: location) else {
+            guard let (resultingKeywordRange, resultingKeywordSlice) = text.interlinkKeyword(at: location) else {
                 continue
             }
 
             XCTAssertEqual(resultingKeywordSlice, expectedKeywordSlice)
-            XCTAssertEqual(resultingKeywordIndex, text.location(for: rangeOfKeyword.lowerBound))
+            XCTAssertEqual(expectedKeywordSlice, String(text[resultingKeywordRange]))
         }
     }
 

--- a/Tests/SimplenoteInterlinksTests/StringInterlinkTests.swift
+++ b/Tests/SimplenoteInterlinksTests/StringInterlinkTests.swift
@@ -4,327 +4,329 @@ import XCTest
 
 // MARK: - String+Interlink Unit Tests
 //
-class StringInterlinkTests: XCTestCase {
-
-    /// Verifies that `interlinkKeyword(at:)` returns nil whenever the `[keyword` is not located at the left hand side of the specified location
-    ///
-    func testInterlinkKeywordReturnsNilWheneverTheSpecifiedLocationDoesNotContainTrailingOpeningBrackets() {
-        let keyword = "Some long keyword should be here"
-        let text = "irrelevant prefix string here [" + keyword
-
-        let rangeOfKeyword = text.range(of: keyword)!
-        let locationOfKeyword = text.location(for: rangeOfKeyword.lowerBound)
-
-        for location in 0..<locationOfKeyword {
-            XCTAssertNil(text.interlinkKeyword(at: location))
-        }
-    }
-
-    /// Verifies that `interlinkKeyword(at:)` returns the `[keyword substring` at the specified location
-    /// We use a `sample text containing [a simplenote innerlink`, and verify the keyword on the left hand side is always returned
-    ///
-    func testInterlinkKeywordReturnsTheTextOnTheLeftHandSideOfTheSpecifiedLocationAndPerformsSuper() {
-        let keyword = "Some long keyword should be here"
-        let lhs = String(repeating: "an extremely long text should probably go here ", count: 2048)
-        let text = lhs + "[" + keyword
-
-        let rangeOfKeyword = text.range(of: keyword)!
-        let locationOfKeyword = text.location(for: rangeOfKeyword.lowerBound)
-
-        for location in locationOfKeyword...text.count {
-            let currentIndex = text.index(for: location)
-            let expectedKeywordSlice = String(text[rangeOfKeyword.lowerBound ..< currentIndex])
-            guard let (resultingKeywordRange, resultingKeywordSlice) = text.interlinkKeyword(at: location) else {
-                continue
-            }
-
-            XCTAssertEqual(resultingKeywordSlice, expectedKeywordSlice)
-            XCTAssertEqual(expectedKeywordSlice, String(text[resultingKeywordRange]))
-        }
-    }
-
-    /// Verifies that `interlinkKeyword(at:)` returns nil whenever the receiver contains an Opening Bracket, but no text
-    ///
-    func testInterlinkKeywordReturnsNilWheneverThereIsNoTextAfterOpeningBracket() {
-        let text = "["
-        XCTAssertNil(text.interlinkKeyword(at: .zero))
-    }
-
-    /// Verifies that `interlinkKeyword(at:)` returns nil whenever the receiver contains a properly closed Interlink
-    ///
-    func testInterlinkKeywordReturnsNilWheneverTheBracketsAreClosed() {
-        let text = "irrelevant prefix string here [Some text should also go here maybe!]"
-
-        for location in 0..<text.count {
-            XCTAssertNil(text.interlinkKeyword(at: location))
-        }
-    }
-
-    /// Verifies that `interlinkKeyword(at:)` can extract a new keyword being edited, located in between two closed keywords
-    ///
-    func testInterlinkKeywordReturnsTheProperSubstringWhenEditingSomeNewLinkInBetweenTwoProperlyFormedLinks() {
-        let keyword = "new keyword"
-        let text = "Hexadecimal is made up of [numbers](simplenote://note/123456) and [" + keyword + " [letters](simplenote://note/abcdef)."
-
-        let rangeOfKeyword = text.range(of: keyword)!
-        let keywordStart = text.location(for: rangeOfKeyword.lowerBound)
-        let keywordEnd = text.location(for: rangeOfKeyword.upperBound)
-
-        for location in keywordStart...keywordEnd {
-            let currentIndex = text.index(for: location)
-            let expectedKeywordSlice = String(text[rangeOfKeyword.lowerBound ..< currentIndex])
-            guard let (resultingKeywordRange, resultingKeywordSlice) = text.interlinkKeyword(at: location) else {
-                continue
-            }
-
-            XCTAssertEqual(resultingKeywordSlice, expectedKeywordSlice)
-            XCTAssertEqual(expectedKeywordSlice, String(text[resultingKeywordRange]))
-        }
-    }
-
-    /// Verifies that `containsUnbalancedClosingCharacter` returns true whenever the receiver contains unbalanced balanced `[]` pairs
-    ///
-    func testContainsUnbalancedClosingCharacterReturnsTrueWhenTheReceiverContainsUnbalancedClosingCharacters() {
-        let samples = [
-            "][]",
-            "[]]",
-        ]
-
-        for sample in samples {
-            XCTAssertTrue(sample.containsUnbalancedClosingCharacter(opening: Character("["), closing: Character("]")))
-        }
-    }
-
-    /// Verifies that `containsUnbalancedClosingCharacter` returns false whenever the receiver contains properly balanced `[]` pairs
-    ///
-    func testContainsUnbalancedClosingCharacterReturnsFalseWhenTheReceiverDoesNotContainUnbalancedClosingCharacters() {
-        let samples = [
-            "[]",
-            "[[]]",
-            "[[[]]]",
-            "[][][]"
-        ]
-
-        for sample in samples {
-            XCTAssertFalse(sample.containsUnbalancedClosingCharacter(opening: Character("["), closing: Character("]")))
-        }
-    }
-
-    /// Verifies that `containsUnbalancedClosingCharacter` returns false whenever there are unbalanced Opening Characters, but not Closing
-    ///
-    func testContainsUnbalancedClosingCharacterReturnsFalseWhenThereAreOnlyUnblancedOpeningCharacters() {
-        let samples = [
-            "[",
-            "[][",
-            "[[]][",
-            "[[[]]][",
-        ]
-
-        for sample in samples {
-            XCTAssertFalse(sample.containsUnbalancedClosingCharacter(opening: Character("["), closing: Character("]")))
-        }
-    }
-
-    /// Verifies that `trailingLookupKeyword(opening: closing)` returns nil whenever the receiver does not contain any lookup keywords
-    ///
-    func testTrailingLookupKeywordReturnsNilWhenThereAreNoLookupKeywords() {
-        let text = "qwertyuiop"
-        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
-
-        XCTAssertNil(result)
-    }
-
-    /// Verifies that `trailingLookupKeyword(opening: closing)` returns nil whenever the receiver contains a closed keyword
-    ///
-    func testTrailingLookupKeywordReturnsNilWhenTheLookupKeywordIsClosedYetEmpty() {
-        let text = "[]"
-        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
-
-        XCTAssertNil(result)
-    }
-
-    /// Verifies that `trailingLookupKeyword(opening: closing)` returns nil whenever the receiver contains multiple closed keywords
-    ///
-    func testTrailingLookupKeywordReturnsNilWhenThereAreNoUnclosedLookupKeywords() {
-        let text = "[keyword 1] lalalala [keyword 2] lalalalaa [keyword 3]"
-        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
-
-        XCTAssertNil(result)
-    }
-
-    /// Verifies that `trailingLookupKeyword(opening: closing)` returns any trailing `[lookup keyword`
-    /// - Note: It must not contain a closing `]`!
-    ///
-    func testTrailingLookupKeywordReturnsTheKeywordAfterTheOpeningCharacter() {
-        let keyword = "some keyword here"
-        let text = "qwertyuiop [" + keyword
-        let range = text.range(of: keyword)
-
-        guard let (resultIndex, resultText) = text.trailingLookupKeyword(opening: "[", closing: "]") else {
-            XCTFail()
-            return
-        }
-
-        XCTAssertEqual(resultText, keyword)
-        XCTAssertEqual(range?.lowerBound, resultIndex)
-    }
-
-    /// Verifies that `trailingLookupKeyword(opening: closing)` returns the trailing `[lookup keyword`, whenever there's more than one keyword
-    ///
-    func testTrailingLookupKeywordReturnsTheLastKeywordWhenThereAreManyKeywords() {
-        let keyword1 = "some keyword here"
-        let keyword2 = "the real keyword"
-
-        let text = "qwertyuiop [" + keyword1 + "] asdfghjkl [" + keyword2
-        let range = text.range(of: keyword2)
-
-        guard let (resultIndex, resultText) = text.trailingLookupKeyword(opening: "[", closing: "]") else {
-            XCTFail()
-            return
-        }
-
-        XCTAssertEqual(resultText, keyword2)
-        XCTAssertEqual(range?.lowerBound, resultIndex)
-    }
-
-    /// Verifies that `trailingLookupKeyword(opening: closing)` works as expected, when the receiver actually starts with the `[lookup keyword`
-    ///
-    func testTrailingLookupKeywordWorksAsExpectedWheneverTheInputStringStartsWithTheOpeningCharacter() {
-        let keyword = "some keyword here"
-        let text = "[" + keyword
-        let range = text.range(of: keyword)
-
-        guard let (resultIndex, resultText) = text.trailingLookupKeyword(opening: "[", closing: "]") else {
-            XCTFail()
-            return
-        }
-
-        XCTAssertEqual(resultText, keyword)
-        XCTAssertEqual(range?.lowerBound, resultIndex)
-    }
-
-    /// Verifies that `trailingLookupKeyword(opening: closing)` returns nil whenever the receiver only contains an  opening character `[`
-    ///
-    func testTrailingLookupKeywordReturnsNilWhenTheActualKeywordIsEmpty() {
-        let text = "["
-        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
-
-        XCTAssertNil(result)
-    }
-
-
-
-    /// Verifies that `split(at:)` properly cuts the receiver at the specified location
-    ///
-    func testSplitAtLocationReturnsTheExpectedSubstrings() {
-        let lhs = "some random text on the left hand side"
-        let rhs = "and some more random text on the right hand side"
-        let text = lhs + rhs
-
-        let (splitLHS, splitRHS) = text.split(at: lhs.count)
-        XCTAssertEqual(lhs, splitLHS)
-        XCTAssertEqual(rhs, splitRHS)
-    }
-
-    /// Verifies that `split(at:)` properly handles Empty Strings
-    ///
-    func testSplitAtLocationReturnsEmptyStringsWhenTheReceiverIsEmpty() {
-        let (lhs, rhs) = "".split(at: .zero)
-
-        XCTAssertTrue(lhs.isEmpty)
-        XCTAssertTrue(rhs.isEmpty)
-    }
-
-    /// Verifies that `split(at:)` returns an empty `RHS` string, whenever the cut location matches the end of the receiver
-    ///
-    func testSplitAtLocationProperlyHandlesLocationsAtTheEndOfTheString() {
-        let text = "this is supposed to be a single but relatively long line of text"
-        let (lhs, rhs) = text.split(at: text.count)
-
-        XCTAssertEqual(lhs, text)
-        XCTAssertEqual(rhs, "")
-    }
-
-
-    /// Verifies that `rangeOfSubstring` properly builds a `Range<String.Index>` for the substring at the specified Location
-    ///
-    func testRangeOfSubstringAtLocationReturnsTheSwiftRangeForSomeSubstringAtTheSpecifiedLocation() {
-        let text = "Hello 🇮🇳 World 🌎!"
-        let substring = "🌎"
-
-        let expectedRange = text.range(of: substring)!
-        let location = text.location(for: expectedRange.lowerBound)
-
-        let resultingRange = text.rangeOfSubstring(at: location, length: substring.count)
-        XCTAssertEqual(expectedRange, resultingRange)
-    }
-
-
-    /// Verifies that `relativeLocation(for: in:)` does not alter the Location, whenever the specified Range covers the full string
-    ///
-    func testRelativeLocationForLocationReturnsTheUnmodifiedLocationWhenTheRangeEnclosesTheFullString() {
-        let text = "this is supposed to be a single but relatively long line of text"
-
-        let substringRange = text.startIndex ..< text.endIndex
-        let substringStart = text.location(for: substringRange.lowerBound)
-        let substringEnd = text.location(for: substringRange.upperBound)
-
-        for location in substringStart..<substringEnd {
-            XCTAssertEqual(text.relativeLocation(for: location, in: substringRange), location)
-        }
-    }
-
-    /// Verifies that `relativeLocation(for: in:)` converts the specified Absolute Location into a Relative Location, with regards of a specified range
-    ///
-    func testRelativeLocationForLocationReturnsTheExpectedLocationWhenTheRangeIsNotTheFullString() {
-        let text = "this is supposed to be a single but relatively long line of text"
-
-        let substringRange = text.range(of: "line of text")!
-        let substringStart = text.location(for: substringRange.lowerBound)
-        let substringEnd = text.location(for: substringRange.upperBound)
-
-        for location in substringStart..<substringEnd {
-            XCTAssertEqual(text.relativeLocation(for: location, in: substringRange), location - substringStart)
-        }
-    }
-
-
-
-    /// Verifies that `line(at:)` returns a touple with Range + Text for the Line at the specified Location
-    ///
-    func testLineAtLocationReturnsTheExpectedLineForTheSpecifiedLocation() {
-        let lines = [
-            "alala lala long long le long long long!\n",
-            "this is supposed to be the second line\n",
-            "and this would be the third line in the document\n",
-            "only to be followed by a trailing and final line!"
-        ]
-
-        let text = lines.joined()
-        var padding = Int.zero
-
-        for line in lines {
-            for location in Int.zero ..< line.count {
-                let (_, lineText) = text.line(at: location + padding)!
-                XCTAssertEqual(lineText, line)
-            }
-
-            padding += line.count
-        }
-    }
-
-
-
-    /// Verifies that `rangeOfLine(at:)` returns `nil` whenever the specified location exceeds the receiver's length.
-    ///
-    func testLineAtLocationReturnsNilWheneverTheLocationExceedsTheValidBounds() {
-        let text = "text and some more text yes!"
-        let locationStart = text.count + 1
-        let locationEnd = text.count * 2
-
-        for location in locationStart ..< locationEnd {
-            XCTAssertNil(text.rangeOfLine(at: location))
-        }
-    }
-}
-
+//class StringInterlinkTests: XCTestCase {
+//
+//    /// Verifies that `interlinkKeyword(at:)` returns nil whenever the `[keyword` is not located at the left hand side of the specified location
+//    ///
+//    func testInterlinkKeywordReturnsNilWheneverTheSpecifiedLocationDoesNotContainTrailingOpeningBrackets() {
+//        let keyword = "Some long keyword should be here"
+//        let text = "irrelevant prefix string here [" + keyword
+//
+//        let rangeOfKeyword = text.range(of: keyword)!
+//        let locationOfKeyword = text.location(for: rangeOfKeyword.lowerBound)
+//
+//        for location in 0..<locationOfKeyword {
+//
+//            XCTAssertNil(text.interlinkKeyword(at: location))
+//        }
+//    }
+//
+//    /// Verifies that `interlinkKeyword(at:)` returns the `[keyword substring` at the specified location
+//    /// We use a `sample text containing [a simplenote innerlink`, and verify the keyword on the left hand side is always returned
+//    ///
+//    func testInterlinkKeywordReturnsTheTextOnTheLeftHandSideOfTheSpecifiedLocationAndPerformsSuper() {
+//        let keyword = "Some long keyword should be here"
+//        let lhs = String(repeating: "an extremely long text should probably go here ", count: 2048)
+//        let text = lhs + "[" + keyword
+//
+//        let rangeOfKeyword = text.range(of: keyword)!
+//        let locationOfKeyword = text.location(for: rangeOfKeyword.lowerBound)
+//
+//        for location in locationOfKeyword...text.count {
+//            let currentIndex = text.index(for: location)
+//            let expectedKeywordSlice = String(text[rangeOfKeyword.lowerBound ..< currentIndex])
+//            guard let (resultingKeywordRange, resultingKeywordSlice) = text.interlinkKeyword(at: location) else {
+//                continue
+//            }
+//
+//            XCTAssertEqual(resultingKeywordSlice, expectedKeywordSlice)
+//            XCTAssertEqual(expectedKeywordSlice, String(text[resultingKeywordRange]))
+//        }
+//    }
+//
+//    /// Verifies that `interlinkKeyword(at:)` returns nil whenever the receiver contains an Opening Bracket, but no text
+//    ///
+//    func testInterlinkKeywordReturnsNilWheneverThereIsNoTextAfterOpeningBracket() {
+//        let text = "["
+//        XCTAssertNil(text.interlinkKeyword(at: .zero))
+//    }
+//
+//    /// Verifies that `interlinkKeyword(at:)` returns nil whenever the receiver contains a properly closed Interlink
+//    ///
+//    func testInterlinkKeywordReturnsNilWheneverTheBracketsAreClosed() {
+//        let text = "irrelevant prefix string here [Some text should also go here maybe!]"
+//
+//        for location in 0..<text.count {
+//            XCTAssertNil(text.interlinkKeyword(at: location))
+//        }
+//    }
+//
+//    /// Verifies that `interlinkKeyword(at:)` can extract a new keyword being edited, located in between two closed keywords
+//    ///
+//    func testInterlinkKeywordReturnsTheProperSubstringWhenEditingSomeNewLinkInBetweenTwoProperlyFormedLinks() {
+//        let keyword = "new keyword"
+//        let text = "Hexadecimal is made up of [numbers](simplenote://note/123456) and [" + keyword + " [letters](simplenote://note/abcdef)."
+//
+//        let rangeOfKeyword = text.range(of: keyword)!
+//        let keywordStart = text.location(for: rangeOfKeyword.lowerBound)
+//        let keywordEnd = text.location(for: rangeOfKeyword.upperBound)
+//
+//        for location in keywordStart...keywordEnd {
+//            let currentIndex = text.index(for: location)
+//            let expectedKeywordSlice = String(text[rangeOfKeyword.lowerBound ..< currentIndex])
+//            guard let (resultingKeywordRange, resultingKeywordSlice) = text.interlinkKeyword(at: location) else {
+//                continue
+//            }
+//
+//            XCTAssertEqual(resultingKeywordSlice, expectedKeywordSlice)
+//            XCTAssertEqual(expectedKeywordSlice, String(text[resultingKeywordRange]))
+//        }
+//    }
+//
+//    /// Verifies that `containsUnbalancedClosingCharacter` returns true whenever the receiver contains unbalanced balanced `[]` pairs
+//    ///
+//    func testContainsUnbalancedClosingCharacterReturnsTrueWhenTheReceiverContainsUnbalancedClosingCharacters() {
+//        let samples = [
+//            "][]",
+//            "[]]",
+//        ]
+//
+//        for sample in samples {
+//            XCTAssertTrue(sample.containsUnbalancedClosingCharacter(opening: Character("["), closing: Character("]")))
+//        }
+//    }
+//
+//    /// Verifies that `containsUnbalancedClosingCharacter` returns false whenever the receiver contains properly balanced `[]` pairs
+//    ///
+//    func testContainsUnbalancedClosingCharacterReturnsFalseWhenTheReceiverDoesNotContainUnbalancedClosingCharacters() {
+//        let samples = [
+//            "[]",
+//            "[[]]",
+//            "[[[]]]",
+//            "[][][]"
+//        ]
+//
+//        for sample in samples {
+//            XCTAssertFalse(sample.containsUnbalancedClosingCharacter(opening: Character("["), closing: Character("]")))
+//        }
+//    }
+//
+//    /// Verifies that `containsUnbalancedClosingCharacter` returns false whenever there are unbalanced Opening Characters, but not Closing
+//    ///
+//    func testContainsUnbalancedClosingCharacterReturnsFalseWhenThereAreOnlyUnblancedOpeningCharacters() {
+//        let samples = [
+//            "[",
+//            "[][",
+//            "[[]][",
+//            "[[[]]][",
+//        ]
+//
+//        for sample in samples {
+//            XCTAssertFalse(sample.containsUnbalancedClosingCharacter(opening: Character("["), closing: Character("]")))
+//        }
+//    }
+//
+//    /// Verifies that `trailingLookupKeyword(opening: closing)` returns nil whenever the receiver does not contain any lookup keywords
+//    ///
+//    func testTrailingLookupKeywordReturnsNilWhenThereAreNoLookupKeywords() {
+//        let text = "qwertyuiop"
+//        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
+//
+//        XCTAssertNil(result)
+//    }
+//
+//    /// Verifies that `trailingLookupKeyword(opening: closing)` returns nil whenever the receiver contains a closed keyword
+//    ///
+//    func testTrailingLookupKeywordReturnsNilWhenTheLookupKeywordIsClosedYetEmpty() {
+//        let text = "[]"
+//        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
+//
+//        XCTAssertNil(result)
+//    }
+//
+//    /// Verifies that `trailingLookupKeyword(opening: closing)` returns nil whenever the receiver contains multiple closed keywords
+//    ///
+//    func testTrailingLookupKeywordReturnsNilWhenThereAreNoUnclosedLookupKeywords() {
+//        let text = "[keyword 1] lalalala [keyword 2] lalalalaa [keyword 3]"
+//        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
+//
+//        XCTAssertNil(result)
+//    }
+//
+//    /// Verifies that `trailingLookupKeyword(opening: closing)` returns any trailing `[lookup keyword`
+//    /// - Note: It must not contain a closing `]`!
+//    ///
+//    func testTrailingLookupKeywordReturnsTheKeywordAfterTheOpeningCharacter() {
+//        let keyword = "some keyword here"
+//        let text = "qwertyuiop [" + keyword
+//        let range = text.range(of: keyword)
+//
+//        guard let (resultIndex, resultText) = text.trailingLookupKeyword(opening: "[", closing: "]") else {
+//            XCTFail()
+//            return
+//        }
+//
+//        XCTAssertEqual(resultText, keyword)
+//        XCTAssertEqual(range?.lowerBound, resultIndex)
+//    }
+//
+//    /// Verifies that `trailingLookupKeyword(opening: closing)` returns the trailing `[lookup keyword`, whenever there's more than one keyword
+//    ///
+//    func testTrailingLookupKeywordReturnsTheLastKeywordWhenThereAreManyKeywords() {
+//        let keyword1 = "some keyword here"
+//        let keyword2 = "the real keyword"
+//
+//        let text = "qwertyuiop [" + keyword1 + "] asdfghjkl [" + keyword2
+//        let range = text.range(of: keyword2)
+//
+//        guard let (resultIndex, resultText) = text.trailingLookupKeyword(opening: "[", closing: "]") else {
+//            XCTFail()
+//            return
+//        }
+//
+//        XCTAssertEqual(resultText, keyword2)
+//        XCTAssertEqual(range?.lowerBound, resultIndex)
+//    }
+//
+//    /// Verifies that `trailingLookupKeyword(opening: closing)` works as expected, when the receiver actually starts with the `[lookup keyword`
+//    ///
+//    func testTrailingLookupKeywordWorksAsExpectedWheneverTheInputStringStartsWithTheOpeningCharacter() {
+//        let keyword = "some keyword here"
+//        let text = "[" + keyword
+//        let range = text.range(of: keyword)
+//
+//        guard let (resultIndex, resultText) = text.trailingLookupKeyword(opening: "[", closing: "]") else {
+//            XCTFail()
+//            return
+//        }
+//
+//        XCTAssertEqual(resultText, keyword)
+//        XCTAssertEqual(range?.lowerBound, resultIndex)
+//    }
+//
+//    /// Verifies that `trailingLookupKeyword(opening: closing)` returns nil whenever the receiver only contains an  opening character `[`
+//    ///
+//    func testTrailingLookupKeywordReturnsNilWhenTheActualKeywordIsEmpty() {
+//        let text = "["
+//        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
+//
+//        XCTAssertNil(result)
+//    }
+//
+//
+//
+//    /// Verifies that `split(at:)` properly cuts the receiver at the specified location
+//    ///
+//    func testSplitAtLocationReturnsTheExpectedSubstrings() {
+//        let lhs = "some random text on the left hand side"
+//        let rhs = "and some more random text on the right hand side"
+//        let text = lhs + rhs
+//
+//        let (splitLHS, splitRHS) = text.split(at: lhs.count)
+//        XCTAssertEqual(lhs, splitLHS)
+//        XCTAssertEqual(rhs, splitRHS)
+//    }
+//
+//    /// Verifies that `split(at:)` properly handles Empty Strings
+//    ///
+//    func testSplitAtLocationReturnsEmptyStringsWhenTheReceiverIsEmpty() {
+//        let (lhs, rhs) = "".split(at: .zero)
+//
+//        XCTAssertTrue(lhs.isEmpty)
+//        XCTAssertTrue(rhs.isEmpty)
+//    }
+//
+//    /// Verifies that `split(at:)` returns an empty `RHS` string, whenever the cut location matches the end of the receiver
+//    ///
+//    func testSplitAtLocationProperlyHandlesLocationsAtTheEndOfTheString() {
+//        let text = "this is supposed to be a single but relatively long line of text"
+//        let (lhs, rhs) = text.split(at: text.count)
+//
+//        XCTAssertEqual(lhs, text)
+//        XCTAssertEqual(rhs, "")
+//    }
+//
+//
+//    /// Verifies that `rangeOfSubstring` properly builds a `Range<String.Index>` for the substring at the specified Location
+//    ///
+//    func testRangeOfSubstringAtLocationReturnsTheSwiftRangeForSomeSubstringAtTheSpecifiedLocation() {
+//        let text = "Hello 🇮🇳 World 🌎!"
+//        let substring = "🌎"
+//
+//        let expectedRange = text.range(of: substring)!
+//        let location = text.location(for: expectedRange.lowerBound)
+//
+//        let resultingRange = text.rangeOfSubstring(at: location, length: substring.count)
+//        XCTAssertEqual(expectedRange, resultingRange)
+//    }
+//
+//
+//    /// Verifies that `relativeLocation(for: in:)` does not alter the Location, whenever the specified Range covers the full string
+//    ///
+//    func testRelativeLocationForLocationReturnsTheUnmodifiedLocationWhenTheRangeEnclosesTheFullString() {
+//        let text = "this is supposed to be a single but relatively long line of text"
+//
+//        let substringRange = text.startIndex ..< text.endIndex
+//        let substringStart = text.location(for: substringRange.lowerBound)
+//        let substringEnd = text.location(for: substringRange.upperBound)
+//
+//        for location in substringStart..<substringEnd {
+//            XCTAssertEqual(text.relativeLocation(for: location, in: substringRange), location)
+//        }
+//    }
+//
+//    /// Verifies that `relativeLocation(for: in:)` converts the specified Absolute Location into a Relative Location, with regards of a specified range
+//    ///
+//    func testRelativeLocationForLocationReturnsTheExpectedLocationWhenTheRangeIsNotTheFullString() {
+//        let text = "this is supposed to be a single but relatively long line of text"
+//
+//        let substringRange = text.range(of: "line of text")!
+//        let substringStart = text.location(for: substringRange.lowerBound)
+//        let substringEnd = text.location(for: substringRange.upperBound)
+//
+//        for location in substringStart..<substringEnd {
+//            XCTAssertEqual(text.relativeLocation(for: location, in: substringRange), location - substringStart)
+//        }
+//    }
+//
+//
+//
+//    /// Verifies that `line(at:)` returns a touple with Range + Text for the Line at the specified Location
+//    ///
+//    func testLineAtLocationReturnsTheExpectedLineForTheSpecifiedLocation() {
+//        let lines = [
+//            "alala lala long long le long long long!\n",
+//            "this is supposed to be the second line\n",
+//            "and this would be the third line in the document\n",
+//            "only to be followed by a trailing and final line!"
+//        ]
+//
+//        let text = lines.joined()
+//        var padding = Int.zero
+//
+//        for line in lines {
+//            for location in Int.zero ..< line.count {
+//                let (_, lineText) = text.line(at: location + padding)!
+//                XCTAssertEqual(lineText, line)
+//            }
+//
+//            padding += line.count
+//        }
+//    }
+//
+//
+//
+//    /// Verifies that `rangeOfLine(at:)` returns `nil` whenever the specified location exceeds the receiver's length.
+//    ///
+//    func testLineAtLocationReturnsNilWheneverTheLocationExceedsTheValidBounds() {
+//        let text = "text and some more text yes!"
+//        let locationStart = text.count + 1
+//        let locationEnd = text.count * 2
+//
+//        for location in locationStart ..< locationEnd {
+//            let index = text.index(for: location)!
+//            XCTAssertNil(text.rangeOfLine(at: index))
+//        }
+//    }
+//}
+//

--- a/Tests/SimplenoteInterlinksTests/StringInterlinkTests.swift
+++ b/Tests/SimplenoteInterlinksTests/StringInterlinkTests.swift
@@ -86,10 +86,8 @@ class StringInterlinkTests: XCTestCase {
     ///
     func testContainsUnbalancedClosingCharacterReturnsTrueWhenTheReceiverContainsUnbalancedClosingCharacters() {
         let samples = [
-            "[][",
             "][]",
-            "[[]][",
-            "[[]]["
+            "[]]",
         ]
 
         for sample in samples {
@@ -105,6 +103,21 @@ class StringInterlinkTests: XCTestCase {
             "[[]]",
             "[[[]]]",
             "[][][]"
+        ]
+
+        for sample in samples {
+            XCTAssertFalse(sample.containsUnbalancedClosingCharacter(opening: Character("["), closing: Character("]")))
+        }
+    }
+
+    /// Verifies that `containsUnbalancedClosingCharacter` returns false whenever there are unbalanced Opening Characters, but not Closing
+    ///
+    func testContainsUnbalancedClosingCharacterReturnsFalseWhenThereAreOnlyUnblancedOpeningCharacters() {
+        let samples = [
+            "[",
+            "[][",
+            "[[]][",
+            "[[[]]][",
         ]
 
         for sample in samples {

--- a/Tests/SimplenoteInterlinksTests/StringInterlinkTests.swift
+++ b/Tests/SimplenoteInterlinksTests/StringInterlinkTests.swift
@@ -4,329 +4,276 @@ import XCTest
 
 // MARK: - String+Interlink Unit Tests
 //
-//class StringInterlinkTests: XCTestCase {
-//
-//    /// Verifies that `interlinkKeyword(at:)` returns nil whenever the `[keyword` is not located at the left hand side of the specified location
-//    ///
-//    func testInterlinkKeywordReturnsNilWheneverTheSpecifiedLocationDoesNotContainTrailingOpeningBrackets() {
-//        let keyword = "Some long keyword should be here"
-//        let text = "irrelevant prefix string here [" + keyword
-//
-//        let rangeOfKeyword = text.range(of: keyword)!
-//        let locationOfKeyword = text.location(for: rangeOfKeyword.lowerBound)
-//
-//        for location in 0..<locationOfKeyword {
-//
-//            XCTAssertNil(text.interlinkKeyword(at: location))
-//        }
-//    }
-//
-//    /// Verifies that `interlinkKeyword(at:)` returns the `[keyword substring` at the specified location
-//    /// We use a `sample text containing [a simplenote innerlink`, and verify the keyword on the left hand side is always returned
-//    ///
-//    func testInterlinkKeywordReturnsTheTextOnTheLeftHandSideOfTheSpecifiedLocationAndPerformsSuper() {
-//        let keyword = "Some long keyword should be here"
-//        let lhs = String(repeating: "an extremely long text should probably go here ", count: 2048)
-//        let text = lhs + "[" + keyword
-//
-//        let rangeOfKeyword = text.range(of: keyword)!
-//        let locationOfKeyword = text.location(for: rangeOfKeyword.lowerBound)
-//
-//        for location in locationOfKeyword...text.count {
-//            let currentIndex = text.index(for: location)
-//            let expectedKeywordSlice = String(text[rangeOfKeyword.lowerBound ..< currentIndex])
-//            guard let (resultingKeywordRange, resultingKeywordSlice) = text.interlinkKeyword(at: location) else {
-//                continue
-//            }
-//
-//            XCTAssertEqual(resultingKeywordSlice, expectedKeywordSlice)
-//            XCTAssertEqual(expectedKeywordSlice, String(text[resultingKeywordRange]))
-//        }
-//    }
-//
-//    /// Verifies that `interlinkKeyword(at:)` returns nil whenever the receiver contains an Opening Bracket, but no text
-//    ///
-//    func testInterlinkKeywordReturnsNilWheneverThereIsNoTextAfterOpeningBracket() {
-//        let text = "["
-//        XCTAssertNil(text.interlinkKeyword(at: .zero))
-//    }
-//
-//    /// Verifies that `interlinkKeyword(at:)` returns nil whenever the receiver contains a properly closed Interlink
-//    ///
-//    func testInterlinkKeywordReturnsNilWheneverTheBracketsAreClosed() {
-//        let text = "irrelevant prefix string here [Some text should also go here maybe!]"
-//
-//        for location in 0..<text.count {
-//            XCTAssertNil(text.interlinkKeyword(at: location))
-//        }
-//    }
-//
-//    /// Verifies that `interlinkKeyword(at:)` can extract a new keyword being edited, located in between two closed keywords
-//    ///
-//    func testInterlinkKeywordReturnsTheProperSubstringWhenEditingSomeNewLinkInBetweenTwoProperlyFormedLinks() {
-//        let keyword = "new keyword"
-//        let text = "Hexadecimal is made up of [numbers](simplenote://note/123456) and [" + keyword + " [letters](simplenote://note/abcdef)."
-//
-//        let rangeOfKeyword = text.range(of: keyword)!
-//        let keywordStart = text.location(for: rangeOfKeyword.lowerBound)
-//        let keywordEnd = text.location(for: rangeOfKeyword.upperBound)
-//
-//        for location in keywordStart...keywordEnd {
-//            let currentIndex = text.index(for: location)
-//            let expectedKeywordSlice = String(text[rangeOfKeyword.lowerBound ..< currentIndex])
-//            guard let (resultingKeywordRange, resultingKeywordSlice) = text.interlinkKeyword(at: location) else {
-//                continue
-//            }
-//
-//            XCTAssertEqual(resultingKeywordSlice, expectedKeywordSlice)
-//            XCTAssertEqual(expectedKeywordSlice, String(text[resultingKeywordRange]))
-//        }
-//    }
-//
-//    /// Verifies that `containsUnbalancedClosingCharacter` returns true whenever the receiver contains unbalanced balanced `[]` pairs
-//    ///
-//    func testContainsUnbalancedClosingCharacterReturnsTrueWhenTheReceiverContainsUnbalancedClosingCharacters() {
-//        let samples = [
-//            "][]",
-//            "[]]",
-//        ]
-//
-//        for sample in samples {
-//            XCTAssertTrue(sample.containsUnbalancedClosingCharacter(opening: Character("["), closing: Character("]")))
-//        }
-//    }
-//
-//    /// Verifies that `containsUnbalancedClosingCharacter` returns false whenever the receiver contains properly balanced `[]` pairs
-//    ///
-//    func testContainsUnbalancedClosingCharacterReturnsFalseWhenTheReceiverDoesNotContainUnbalancedClosingCharacters() {
-//        let samples = [
-//            "[]",
-//            "[[]]",
-//            "[[[]]]",
-//            "[][][]"
-//        ]
-//
-//        for sample in samples {
-//            XCTAssertFalse(sample.containsUnbalancedClosingCharacter(opening: Character("["), closing: Character("]")))
-//        }
-//    }
-//
-//    /// Verifies that `containsUnbalancedClosingCharacter` returns false whenever there are unbalanced Opening Characters, but not Closing
-//    ///
-//    func testContainsUnbalancedClosingCharacterReturnsFalseWhenThereAreOnlyUnblancedOpeningCharacters() {
-//        let samples = [
-//            "[",
-//            "[][",
-//            "[[]][",
-//            "[[[]]][",
-//        ]
-//
-//        for sample in samples {
-//            XCTAssertFalse(sample.containsUnbalancedClosingCharacter(opening: Character("["), closing: Character("]")))
-//        }
-//    }
-//
-//    /// Verifies that `trailingLookupKeyword(opening: closing)` returns nil whenever the receiver does not contain any lookup keywords
-//    ///
-//    func testTrailingLookupKeywordReturnsNilWhenThereAreNoLookupKeywords() {
-//        let text = "qwertyuiop"
-//        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
-//
-//        XCTAssertNil(result)
-//    }
-//
-//    /// Verifies that `trailingLookupKeyword(opening: closing)` returns nil whenever the receiver contains a closed keyword
-//    ///
-//    func testTrailingLookupKeywordReturnsNilWhenTheLookupKeywordIsClosedYetEmpty() {
-//        let text = "[]"
-//        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
-//
-//        XCTAssertNil(result)
-//    }
-//
-//    /// Verifies that `trailingLookupKeyword(opening: closing)` returns nil whenever the receiver contains multiple closed keywords
-//    ///
-//    func testTrailingLookupKeywordReturnsNilWhenThereAreNoUnclosedLookupKeywords() {
-//        let text = "[keyword 1] lalalala [keyword 2] lalalalaa [keyword 3]"
-//        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
-//
-//        XCTAssertNil(result)
-//    }
-//
-//    /// Verifies that `trailingLookupKeyword(opening: closing)` returns any trailing `[lookup keyword`
-//    /// - Note: It must not contain a closing `]`!
-//    ///
-//    func testTrailingLookupKeywordReturnsTheKeywordAfterTheOpeningCharacter() {
-//        let keyword = "some keyword here"
-//        let text = "qwertyuiop [" + keyword
-//        let range = text.range(of: keyword)
-//
-//        guard let (resultIndex, resultText) = text.trailingLookupKeyword(opening: "[", closing: "]") else {
-//            XCTFail()
-//            return
-//        }
-//
-//        XCTAssertEqual(resultText, keyword)
-//        XCTAssertEqual(range?.lowerBound, resultIndex)
-//    }
-//
-//    /// Verifies that `trailingLookupKeyword(opening: closing)` returns the trailing `[lookup keyword`, whenever there's more than one keyword
-//    ///
-//    func testTrailingLookupKeywordReturnsTheLastKeywordWhenThereAreManyKeywords() {
-//        let keyword1 = "some keyword here"
-//        let keyword2 = "the real keyword"
-//
-//        let text = "qwertyuiop [" + keyword1 + "] asdfghjkl [" + keyword2
-//        let range = text.range(of: keyword2)
-//
-//        guard let (resultIndex, resultText) = text.trailingLookupKeyword(opening: "[", closing: "]") else {
-//            XCTFail()
-//            return
-//        }
-//
-//        XCTAssertEqual(resultText, keyword2)
-//        XCTAssertEqual(range?.lowerBound, resultIndex)
-//    }
-//
-//    /// Verifies that `trailingLookupKeyword(opening: closing)` works as expected, when the receiver actually starts with the `[lookup keyword`
-//    ///
-//    func testTrailingLookupKeywordWorksAsExpectedWheneverTheInputStringStartsWithTheOpeningCharacter() {
-//        let keyword = "some keyword here"
-//        let text = "[" + keyword
-//        let range = text.range(of: keyword)
-//
-//        guard let (resultIndex, resultText) = text.trailingLookupKeyword(opening: "[", closing: "]") else {
-//            XCTFail()
-//            return
-//        }
-//
-//        XCTAssertEqual(resultText, keyword)
-//        XCTAssertEqual(range?.lowerBound, resultIndex)
-//    }
-//
-//    /// Verifies that `trailingLookupKeyword(opening: closing)` returns nil whenever the receiver only contains an  opening character `[`
-//    ///
-//    func testTrailingLookupKeywordReturnsNilWhenTheActualKeywordIsEmpty() {
-//        let text = "["
-//        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
-//
-//        XCTAssertNil(result)
-//    }
-//
-//
-//
-//    /// Verifies that `split(at:)` properly cuts the receiver at the specified location
-//    ///
-//    func testSplitAtLocationReturnsTheExpectedSubstrings() {
-//        let lhs = "some random text on the left hand side"
-//        let rhs = "and some more random text on the right hand side"
-//        let text = lhs + rhs
-//
-//        let (splitLHS, splitRHS) = text.split(at: lhs.count)
-//        XCTAssertEqual(lhs, splitLHS)
-//        XCTAssertEqual(rhs, splitRHS)
-//    }
-//
-//    /// Verifies that `split(at:)` properly handles Empty Strings
-//    ///
-//    func testSplitAtLocationReturnsEmptyStringsWhenTheReceiverIsEmpty() {
-//        let (lhs, rhs) = "".split(at: .zero)
-//
-//        XCTAssertTrue(lhs.isEmpty)
-//        XCTAssertTrue(rhs.isEmpty)
-//    }
-//
-//    /// Verifies that `split(at:)` returns an empty `RHS` string, whenever the cut location matches the end of the receiver
-//    ///
-//    func testSplitAtLocationProperlyHandlesLocationsAtTheEndOfTheString() {
-//        let text = "this is supposed to be a single but relatively long line of text"
-//        let (lhs, rhs) = text.split(at: text.count)
-//
-//        XCTAssertEqual(lhs, text)
-//        XCTAssertEqual(rhs, "")
-//    }
-//
-//
-//    /// Verifies that `rangeOfSubstring` properly builds a `Range<String.Index>` for the substring at the specified Location
-//    ///
-//    func testRangeOfSubstringAtLocationReturnsTheSwiftRangeForSomeSubstringAtTheSpecifiedLocation() {
-//        let text = "Hello 🇮🇳 World 🌎!"
-//        let substring = "🌎"
-//
-//        let expectedRange = text.range(of: substring)!
-//        let location = text.location(for: expectedRange.lowerBound)
-//
-//        let resultingRange = text.rangeOfSubstring(at: location, length: substring.count)
-//        XCTAssertEqual(expectedRange, resultingRange)
-//    }
-//
-//
-//    /// Verifies that `relativeLocation(for: in:)` does not alter the Location, whenever the specified Range covers the full string
-//    ///
-//    func testRelativeLocationForLocationReturnsTheUnmodifiedLocationWhenTheRangeEnclosesTheFullString() {
-//        let text = "this is supposed to be a single but relatively long line of text"
-//
-//        let substringRange = text.startIndex ..< text.endIndex
-//        let substringStart = text.location(for: substringRange.lowerBound)
-//        let substringEnd = text.location(for: substringRange.upperBound)
-//
-//        for location in substringStart..<substringEnd {
-//            XCTAssertEqual(text.relativeLocation(for: location, in: substringRange), location)
-//        }
-//    }
-//
-//    /// Verifies that `relativeLocation(for: in:)` converts the specified Absolute Location into a Relative Location, with regards of a specified range
-//    ///
-//    func testRelativeLocationForLocationReturnsTheExpectedLocationWhenTheRangeIsNotTheFullString() {
-//        let text = "this is supposed to be a single but relatively long line of text"
-//
-//        let substringRange = text.range(of: "line of text")!
-//        let substringStart = text.location(for: substringRange.lowerBound)
-//        let substringEnd = text.location(for: substringRange.upperBound)
-//
-//        for location in substringStart..<substringEnd {
-//            XCTAssertEqual(text.relativeLocation(for: location, in: substringRange), location - substringStart)
-//        }
-//    }
-//
-//
-//
-//    /// Verifies that `line(at:)` returns a touple with Range + Text for the Line at the specified Location
-//    ///
-//    func testLineAtLocationReturnsTheExpectedLineForTheSpecifiedLocation() {
-//        let lines = [
-//            "alala lala long long le long long long!\n",
-//            "this is supposed to be the second line\n",
-//            "and this would be the third line in the document\n",
-//            "only to be followed by a trailing and final line!"
-//        ]
-//
-//        let text = lines.joined()
-//        var padding = Int.zero
-//
-//        for line in lines {
-//            for location in Int.zero ..< line.count {
-//                let (_, lineText) = text.line(at: location + padding)!
-//                XCTAssertEqual(lineText, line)
-//            }
-//
-//            padding += line.count
-//        }
-//    }
-//
-//
-//
-//    /// Verifies that `rangeOfLine(at:)` returns `nil` whenever the specified location exceeds the receiver's length.
-//    ///
-//    func testLineAtLocationReturnsNilWheneverTheLocationExceedsTheValidBounds() {
-//        let text = "text and some more text yes!"
-//        let locationStart = text.count + 1
-//        let locationEnd = text.count * 2
-//
-//        for location in locationStart ..< locationEnd {
-//            let index = text.index(for: location)!
-//            XCTAssertNil(text.rangeOfLine(at: index))
-//        }
-//    }
-//}
-//
+class StringInterlinkTests: XCTestCase {
+
+    /// Verifies that `interlinkKeyword(at:)` returns nil whenever the `[keyword` is not located at the left hand side of the specified location
+    ///
+    func testInterlinkKeywordReturnsNilWheneverTheSpecifiedLocationDoesNotContainTrailingOpeningBrackets() {
+        let lhs = "irrelevant prefix string here ["
+        let keyword = "Some long keyword should be here"
+        let text = lhs + keyword
+
+        for location in Int.zero ..< lhs.count {
+            let index = text.index(text.startIndex, offsetBy: location)
+            XCTAssertNil(text.interlinkKeyword(at: index))
+        }
+    }
+
+    /// Verifies that `interlinkKeyword(at:)` returns the `[keyword substring` at the specified location
+    /// We use a `sample text containing [a simplenote innerlink`, and verify the keyword on the left hand side is always returned
+    ///
+    func testInterlinkKeywordReturnsTheTextOnTheLeftHandSideOfTheSpecifiedLocationAndPerformsSuper() {
+        let keyword = "Some long keyword should be here"
+        let lhs = String(repeating: "an extremely long text should probably go here ", count: 2048)
+        let text = lhs + "[" + keyword
+
+        let rangeOfKeyword = text.range(of: keyword)!
+        let locationOfKeyword = text.distance(from: text.startIndex, to: rangeOfKeyword.lowerBound) + 1
+
+        for location in locationOfKeyword...text.count {
+            let currentIndex = text.index(text.startIndex, offsetBy: location)
+            let expectedKeywordSlice = String(text[rangeOfKeyword.lowerBound ..< currentIndex])
+
+            guard let (resultingKeywordRange, resultingKeywordSlice) = text.interlinkKeyword(at: currentIndex) else {
+                XCTFail()
+                continue
+            }
+
+            XCTAssertEqual(resultingKeywordSlice, expectedKeywordSlice)
+            XCTAssertEqual(expectedKeywordSlice, String(text[resultingKeywordRange]))
+        }
+    }
+
+    /// Verifies that `interlinkKeyword(at:)` returns nil whenever the receiver contains an Opening Bracket, but no text
+    ///
+    func testInterlinkKeywordReturnsNilWheneverThereIsNoTextAfterOpeningBracket() {
+        let text = "["
+        XCTAssertNil(text.interlinkKeyword(at: text.startIndex))
+    }
+
+    /// Verifies that `interlinkKeyword(at:)` returns nil whenever the receiver contains a properly closed Interlink
+    ///
+    func testInterlinkKeywordReturnsNilWheneverTheBracketsAreClosed() {
+        let text = "irrelevant prefix string here [Some text should also go here maybe!]"
+
+        for location in Int.zero ..< text.count {
+            let index = text.index(text.startIndex, offsetBy: location)
+            XCTAssertNil(text.interlinkKeyword(at: index))
+        }
+    }
+
+    /// Verifies that `interlinkKeyword(at:)` can extract a new keyword being edited, located in between two closed keywords
+    ///
+    func testInterlinkKeywordReturnsTheProperSubstringWhenEditingSomeNewLinkInBetweenTwoProperlyFormedLinks() {
+        let keyword = "new keyword"
+        let text = "Hexadecimal 🇮🇳 🌍 is made up of [numbers](simplenote://note/123456) and [" + keyword + " 🇮🇳 🌍 [letters](simplenote://note/abcdef)."
+
+        let rangeOfKeyword = text.range(of: keyword)!
+        let locationOfKeyword = text.distance(from: text.startIndex, to: rangeOfKeyword.lowerBound) + 1
+
+        // Starting after the first character!
+        for location in locationOfKeyword ... locationOfKeyword + keyword.count {
+            let currentIndex = text.index(text.startIndex, offsetBy: location)
+            let expectedKeywordSlice = String(text[rangeOfKeyword.lowerBound ..< currentIndex])
+
+            guard let (resultingKeywordRange, resultingKeywordSlice) = text.interlinkKeyword(at: currentIndex) else {
+                XCTFail()
+                continue
+            }
+
+            XCTAssertEqual(resultingKeywordSlice, expectedKeywordSlice)
+            XCTAssertEqual(expectedKeywordSlice, String(text[resultingKeywordRange]))
+        }
+    }
+
+    /// Verifies that `containsUnbalancedClosingCharacter` returns true whenever the receiver contains unbalanced balanced `[]` pairs
+    ///
+    func testContainsUnbalancedClosingCharacterReturnsTrueWhenTheReceiverContainsUnbalancedClosingCharacters() {
+        let samples = [
+            "][]",
+            "[]]",
+        ]
+
+        for sample in samples {
+            XCTAssertTrue(sample.containsUnbalancedClosingCharacter(opening: Character("["), closing: Character("]")))
+        }
+    }
+
+    /// Verifies that `containsUnbalancedClosingCharacter` returns false whenever the receiver contains properly balanced `[]` pairs
+    ///
+    func testContainsUnbalancedClosingCharacterReturnsFalseWhenTheReceiverDoesNotContainUnbalancedClosingCharacters() {
+        let samples = [
+            "[]",
+            "[[]]",
+            "[[[]]]",
+            "[][][]"
+        ]
+
+        for sample in samples {
+            XCTAssertFalse(sample.containsUnbalancedClosingCharacter(opening: Character("["), closing: Character("]")))
+        }
+    }
+
+    /// Verifies that `containsUnbalancedClosingCharacter` returns false whenever there are unbalanced Opening Characters, but not Closing
+    ///
+    func testContainsUnbalancedClosingCharacterReturnsFalseWhenThereAreOnlyUnblancedOpeningCharacters() {
+        let samples = [
+            "[",
+            "[][",
+            "[[]][",
+            "[[[]]][",
+        ]
+
+        for sample in samples {
+            XCTAssertFalse(sample.containsUnbalancedClosingCharacter(opening: Character("["), closing: Character("]")))
+        }
+    }
+
+    /// Verifies that `trailingLookupKeyword(opening: closing)` returns nil whenever the receiver does not contain any lookup keywords
+    ///
+    func testTrailingLookupKeywordReturnsNilWhenThereAreNoLookupKeywords() {
+        let text = "qwertyuiop"
+        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
+
+        XCTAssertNil(result)
+    }
+
+    /// Verifies that `trailingLookupKeyword(opening: closing)` returns nil whenever the receiver contains a closed keyword
+    ///
+    func testTrailingLookupKeywordReturnsNilWhenTheLookupKeywordIsClosedYetEmpty() {
+        let text = "[]"
+        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
+
+        XCTAssertNil(result)
+    }
+
+    /// Verifies that `trailingLookupKeyword(opening: closing)` returns nil whenever the receiver contains multiple closed keywords
+    ///
+    func testTrailingLookupKeywordReturnsNilWhenThereAreNoUnclosedLookupKeywords() {
+        let text = "[keyword 1] lalalala [keyword 2] lalalalaa [keyword 3]"
+        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
+
+        XCTAssertNil(result)
+    }
+
+    /// Verifies that `trailingLookupKeyword(opening: closing)` returns any trailing `[lookup keyword`
+    /// - Note: It must not contain a closing `]`!
+    ///
+    func testTrailingLookupKeywordReturnsTheKeywordAfterTheOpeningCharacter() {
+        let keyword = "some keyword here"
+        let text = "qwertyuiop [" + keyword
+        let range = text.range(of: keyword)
+
+        guard let (resultIndex, resultText) = text.trailingLookupKeyword(opening: "[", closing: "]") else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(resultText, keyword)
+        XCTAssertEqual(range?.lowerBound, resultIndex)
+    }
+
+    /// Verifies that `trailingLookupKeyword(opening: closing)` returns the trailing `[lookup keyword`, whenever there's more than one keyword
+    ///
+    func testTrailingLookupKeywordReturnsTheLastKeywordWhenThereAreManyKeywords() {
+        let keyword1 = "some keyword here"
+        let keyword2 = "the real keyword"
+
+        let text = "qwertyuiop [" + keyword1 + "] asdfghjkl [" + keyword2
+        let range = text.range(of: keyword2)
+
+        guard let (resultIndex, resultText) = text.trailingLookupKeyword(opening: "[", closing: "]") else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(resultText, keyword2)
+        XCTAssertEqual(range?.lowerBound, resultIndex)
+    }
+
+    /// Verifies that `trailingLookupKeyword(opening: closing)` works as expected, when the receiver actually starts with the `[lookup keyword`
+    ///
+    func testTrailingLookupKeywordWorksAsExpectedWheneverTheInputStringStartsWithTheOpeningCharacter() {
+        let keyword = "some keyword here"
+        let text = "[" + keyword
+        let range = text.range(of: keyword)
+
+        guard let (resultIndex, resultText) = text.trailingLookupKeyword(opening: "[", closing: "]") else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(resultText, keyword)
+        XCTAssertEqual(range?.lowerBound, resultIndex)
+    }
+
+    /// Verifies that `trailingLookupKeyword(opening: closing)` returns nil whenever the receiver only contains an  opening character `[`
+    ///
+    func testTrailingLookupKeywordReturnsNilWhenTheActualKeywordIsEmpty() {
+        let text = "["
+        let result = text.trailingLookupKeyword(opening: "[", closing: "]")
+
+        XCTAssertNil(result)
+    }
+
+
+    /// Verifies that `split(at:)` properly cuts the receiver at the specified location
+    ///
+    func testSplitAtLocationReturnsTheExpectedSubstrings() {
+        let lhs = "some random 🇮🇳 text on the left hand side"
+        let rhs = "and some more 🌎 random text on the right hand side"
+        let text = lhs + rhs
+        let lhsEndIndex = text.index(text.startIndex, offsetBy: lhs.count)
+
+        let (splitLHS, splitRHS) = text.split(at: lhsEndIndex)
+        XCTAssertEqual(lhs, splitLHS)
+        XCTAssertEqual(rhs, splitRHS)
+    }
+
+    /// Verifies that `split(at:)` properly handles Empty Strings
+    ///
+    func testSplitAtLocationReturnsEmptyStringsWhenTheReceiverIsEmpty() {
+        let text = ""
+        let (lhs, rhs) = text.split(at: text.startIndex)
+
+        XCTAssertTrue(lhs.isEmpty)
+        XCTAssertTrue(rhs.isEmpty)
+    }
+
+    /// Verifies that `split(at:)` returns an empty `RHS` string, whenever the cut location matches the end of the receiver
+    ///
+    func testSplitAtLocationProperlyHandlesLocationsAtTheEndOfTheString() {
+        let text = "this is supposed to be a single but relatively long line of text"
+        let (lhs, rhs) = text.split(at: text.endIndex)
+
+        XCTAssertEqual(lhs, text)
+        XCTAssertEqual(rhs, "")
+    }
+
+    /// Verifies that `line(at:)` returns a touple with Range + Text for the Line at the specified Location
+    ///
+    func testLineAtIndexReturnsTheExpectedLineForTheSpecifiedLocation() {
+        let lines = [
+            "alala lala long long le long long long!\n",
+            "this is supposed to be the second line\n",
+            "and this would be the third line in the document\n",
+            "only to be followed by a trailing and final line!"
+        ]
+
+        let text = lines.joined()
+        var padding = Int.zero
+
+        for line in lines {
+            for location in Int.zero ..< line.count {
+                let index = text.index(text.startIndex, offsetBy: location + padding)
+                let (lineRange, lineText) = text.line(at: index)
+
+                XCTAssertEqual(lineText, line)
+                XCTAssertEqual(String(text[lineRange]), lineText)
+            }
+
+            padding += line.count
+        }
+    }
+}
+


### PR DESCRIPTION
### Details:
- Implements **String+Interlinks** extension
- Wires SimplenoteFoundation dependency
- CircleCI workaround. Because we can't have nice things 😢 
- A million unit tests!

@aerych Sir!! Can I bug you with this one?

**Thank you!!**

### Test
I'm afraid there is no direct way to test this one. Please:

- [x] Verify the unit tests are green!

### Release
These changes do not require release notes.
