### PR TITLE
Interlink: Exposing Markdown Range

### DIFF
--- a/Sources/SimplenoteInterlinks/Extensions/String+Interlinking.swift
+++ b/Sources/SimplenoteInterlinks/Extensions/String+Interlinking.swift
@@ -13,11 +13,14 @@ extension String {
     ///     - opening: Opening Keyword Character
     ///     - closing: Closing Keyword Character
     ///
-    /// - Returns: Keyword, if any.
+    /// - Returns: (Markdown Range, Visual Range and Keyword Text).
+    ///            - Markdown: Contains the opening brace.
+    ///            - Visual: Text Range.
+    ///            - Keyword Text: The actual keyword text
     /// - Note: This API extracts the keyword at a given String.Index, with this shape: `[keyword`.
-    /// - Important: If a closing character is found on the right hand side, this API returns nil
+    /// - Important: If an (unbalanced) closing character is found on the right hand side, this API returns nil
     ///
-    public func interlinkKeyword(at index: String.Index, opening: Character = Character("["), closing: Character = Character("]")) -> (Range<String.Index>, String)? {
+    public func interlinkKeyword(at index: String.Index, opening: Character = Character("["), closing: Character = Character("]")) -> (Range<String.Index>, Range<String.Index>, String)? {
         // Step #0: Determine the Line where we're standing
         let (lineRange, lineText) = line(at: index)
 
@@ -47,7 +50,11 @@ extension String {
         let keywordIndex = self.index(lineRange.lowerBound, offsetBy: lhs.distance(from: lhs.startIndex, to: keywordIndexInLHS))
         let keywordRange = range(for: keywordText, at: keywordIndex)
 
-        return (keywordRange, keywordText)
+        // Step #6: markdown
+        let markdownIndex = self.index(before: keywordIndex)
+        let markdownRange = markdownIndex ..< keywordRange.upperBound
+
+        return (markdownRange, keywordRange, keywordText)
     }
 
     /// Returns the Range for the specified Substring at a given Index

--- a/Tests/SimplenoteInterlinksTests/StringInterlinkTests.swift
+++ b/Tests/SimplenoteInterlinksTests/StringInterlinkTests.swift
@@ -33,14 +33,16 @@ class StringInterlinkTests: XCTestCase {
         for location in locationOfKeyword...text.count {
             let currentIndex = text.index(text.startIndex, offsetBy: location)
             let expectedKeywordSlice = String(text[rangeOfKeyword.lowerBound ..< currentIndex])
+            let expectedMarkdownSlice = "[" + expectedKeywordSlice
 
-            guard let (resultingKeywordRange, resultingKeywordSlice) = text.interlinkKeyword(at: currentIndex) else {
+            guard let (resultingMarkdownRange, resultingKeywordRange, resultingKeywordSlice) = text.interlinkKeyword(at: currentIndex) else {
                 XCTFail()
                 continue
             }
 
             XCTAssertEqual(resultingKeywordSlice, expectedKeywordSlice)
             XCTAssertEqual(expectedKeywordSlice, String(text[resultingKeywordRange]))
+            XCTAssertEqual(String(text[resultingMarkdownRange]), expectedMarkdownSlice)
         }
     }
 
@@ -75,14 +77,16 @@ class StringInterlinkTests: XCTestCase {
         for location in locationOfKeyword ... locationOfKeyword + keyword.count {
             let currentIndex = text.index(text.startIndex, offsetBy: location)
             let expectedKeywordSlice = String(text[rangeOfKeyword.lowerBound ..< currentIndex])
+            let expectedMarkdownSlice = "[" + expectedKeywordSlice
 
-            guard let (resultingKeywordRange, resultingKeywordSlice) = text.interlinkKeyword(at: currentIndex) else {
+            guard let (resultingMarkdownRange, resultingKeywordRange, resultingKeywordSlice) = text.interlinkKeyword(at: currentIndex) else {
                 XCTFail()
                 continue
             }
 
             XCTAssertEqual(resultingKeywordSlice, expectedKeywordSlice)
             XCTAssertEqual(expectedKeywordSlice, String(text[resultingKeywordRange]))
+            XCTAssertEqual(String(text[resultingMarkdownRange]), expectedMarkdownSlice)
         }
     }
 


### PR DESCRIPTION
### Details:
This PR extends the Interlinking Detection API so that the "Full Markdown Substring" range is exposed.
That translates into:

```
Sample String [keyword
```

Now the `interlinkKeyword(at:)` API will return:

1. The Range enclosing the full markdown text. Translates into: `[keyword`
2. The Range enclosing the visual text. Translates into: `keyword`
3. The plain string: `keyword`

### Testing:
Please verify via [this Simplenote Mac PR](https://github.com/Automattic/simplenote-macos/pull/688)

Thank you!!